### PR TITLE
Fix UpdateTotals() calculation and add BR-CO validation

### DIFF
--- a/calculate.go
+++ b/calculate.go
@@ -46,17 +46,33 @@ func (inv *Invoice) UpdateApplicableTradeTax(exemptReason map[string]string) {
 	}
 }
 
-// UpdateTotals collects the sum from the applicable trade taxes and updates the
-// monetary summation. Charges and allowances are currently not considered.
+// UpdateTotals recalculates all monetary totals according to EN 16931 business rules.
+// This function implements the following business rules:
+// - BR-CO-10: LineTotal (BT-106) = Sum of all invoice line net amounts (BT-131)
+// - BR-CO-13: TaxBasisTotal (BT-109) = LineTotal (BT-106) - AllowanceTotal (BT-107) + ChargeTotal (BT-108)
+// - BR-CO-15: GrandTotal (BT-112) = TaxBasisTotal (BT-109) + TaxTotal (BT-110)
+// - BR-CO-16: DuePayableAmount (BT-115) = GrandTotal (BT-112) - TotalPrepaid (BT-113) + RoundingAmount (BT-114)
 func (inv *Invoice) UpdateTotals() {
-	// var chargeTotal decimal.Decimal
-	// var allowanceTotal decimal.Decimal
+	// Reset all calculated totals to zero to ensure idempotent behavior
+	inv.LineTotal = decimal.Zero
+	inv.TaxTotal = decimal.Zero
+
+	// BR-CO-10: Calculate line total from invoice lines (BT-106)
+	for _, line := range inv.InvoiceLines {
+		inv.LineTotal = inv.LineTotal.Add(line.Total)
+	}
+
+	// Calculate tax total from trade taxes (BT-110)
 	for _, v := range inv.TradeTaxes {
-		inv.LineTotal = inv.LineTotal.Add(v.BasisAmount)
 		inv.TaxTotal = inv.TaxTotal.Add(v.CalculatedAmount)
 	}
 
-	inv.TaxBasisTotal = inv.LineTotal
+	// BR-CO-13: Apply document-level allowances and charges to calculate tax basis total
+	inv.TaxBasisTotal = inv.LineTotal.Sub(inv.AllowanceTotal).Add(inv.ChargeTotal)
+
+	// BR-CO-15: Calculate grand total
 	inv.GrandTotal = inv.TaxBasisTotal.Add(inv.TaxTotal)
-	inv.DuePayableAmount = inv.GrandTotal.Sub(inv.TotalPrepaid)
+
+	// BR-CO-16: Calculate due payable amount including rounding
+	inv.DuePayableAmount = inv.GrandTotal.Sub(inv.TotalPrepaid).Add(inv.RoundingAmount)
 }

--- a/calculate_test.go
+++ b/calculate_test.go
@@ -1,0 +1,244 @@
+package einvoice
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestUpdateTotals_BasicCalculation tests the basic calculation of totals from invoice lines
+// according to BR-CO-10: LineTotal should be the sum of all invoice line net amounts
+func TestUpdateTotals_BasicCalculation(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+			{Total: decimal.NewFromFloat(200.00)},
+			{Total: decimal.NewFromFloat(50.50)},
+		},
+		TradeTaxes: []TradeTax{
+			{CalculatedAmount: decimal.NewFromFloat(19.00)},
+			{CalculatedAmount: decimal.NewFromFloat(38.00)},
+		},
+	}
+
+	inv.UpdateTotals()
+
+	// BR-CO-10: LineTotal = Sum of invoice line totals
+	expectedLineTotal := decimal.NewFromFloat(350.50)
+	if !inv.LineTotal.Equal(expectedLineTotal) {
+		t.Errorf("LineTotal = %s, want %s (BR-CO-10)", inv.LineTotal, expectedLineTotal)
+	}
+
+	// TaxTotal = Sum of calculated tax amounts
+	expectedTaxTotal := decimal.NewFromFloat(57.00)
+	if !inv.TaxTotal.Equal(expectedTaxTotal) {
+		t.Errorf("TaxTotal = %s, want %s", inv.TaxTotal, expectedTaxTotal)
+	}
+
+	// BR-CO-13: TaxBasisTotal = LineTotal (no allowances/charges)
+	if !inv.TaxBasisTotal.Equal(expectedLineTotal) {
+		t.Errorf("TaxBasisTotal = %s, want %s (BR-CO-13)", inv.TaxBasisTotal, expectedLineTotal)
+	}
+
+	// BR-CO-15: GrandTotal = TaxBasisTotal + TaxTotal
+	expectedGrandTotal := decimal.NewFromFloat(407.50)
+	if !inv.GrandTotal.Equal(expectedGrandTotal) {
+		t.Errorf("GrandTotal = %s, want %s (BR-CO-15)", inv.GrandTotal, expectedGrandTotal)
+	}
+
+	// BR-CO-16: DuePayableAmount = GrandTotal (no prepaid/rounding)
+	if !inv.DuePayableAmount.Equal(expectedGrandTotal) {
+		t.Errorf("DuePayableAmount = %s, want %s (BR-CO-16)", inv.DuePayableAmount, expectedGrandTotal)
+	}
+}
+
+// TestUpdateTotals_WithAllowancesAndCharges tests that document-level allowances
+// and charges are correctly applied according to BR-CO-13
+func TestUpdateTotals_WithAllowancesAndCharges(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(1000.00)},
+		},
+		TradeTaxes: []TradeTax{
+			{CalculatedAmount: decimal.NewFromFloat(171.00)}, // 19% of 900
+		},
+		AllowanceTotal: decimal.NewFromFloat(150.00), // BT-107
+		ChargeTotal:    decimal.NewFromFloat(50.00),  // BT-108
+	}
+
+	inv.UpdateTotals()
+
+	// BR-CO-10: LineTotal = Sum of invoice lines
+	expectedLineTotal := decimal.NewFromFloat(1000.00)
+	if !inv.LineTotal.Equal(expectedLineTotal) {
+		t.Errorf("LineTotal = %s, want %s (BR-CO-10)", inv.LineTotal, expectedLineTotal)
+	}
+
+	// BR-CO-13: TaxBasisTotal = LineTotal - AllowanceTotal + ChargeTotal
+	// = 1000 - 150 + 50 = 900
+	expectedTaxBasisTotal := decimal.NewFromFloat(900.00)
+	if !inv.TaxBasisTotal.Equal(expectedTaxBasisTotal) {
+		t.Errorf("TaxBasisTotal = %s, want %s (BR-CO-13: LineTotal - AllowanceTotal + ChargeTotal)",
+			inv.TaxBasisTotal, expectedTaxBasisTotal)
+	}
+
+	// BR-CO-15: GrandTotal = TaxBasisTotal + TaxTotal
+	// = 900 + 171 = 1071
+	expectedGrandTotal := decimal.NewFromFloat(1071.00)
+	if !inv.GrandTotal.Equal(expectedGrandTotal) {
+		t.Errorf("GrandTotal = %s, want %s (BR-CO-15)", inv.GrandTotal, expectedGrandTotal)
+	}
+}
+
+// TestUpdateTotals_WithRoundingAmount tests that rounding amount is correctly
+// applied according to BR-CO-16
+func TestUpdateTotals_WithRoundingAmount(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+		},
+		TradeTaxes: []TradeTax{
+			{CalculatedAmount: decimal.NewFromFloat(19.00)},
+		},
+		TotalPrepaid:   decimal.NewFromFloat(50.00),  // BT-113
+		RoundingAmount: decimal.NewFromFloat(-0.14),  // BT-114
+	}
+
+	inv.UpdateTotals()
+
+	// BR-CO-16: DuePayableAmount = GrandTotal - TotalPrepaid + RoundingAmount
+	// = 119.00 - 50.00 + (-0.14) = 68.86
+	expectedDuePayableAmount := decimal.NewFromFloat(68.86)
+	if !inv.DuePayableAmount.Equal(expectedDuePayableAmount) {
+		t.Errorf("DuePayableAmount = %s, want %s (BR-CO-16: GrandTotal - TotalPrepaid + RoundingAmount)",
+			inv.DuePayableAmount, expectedDuePayableAmount)
+	}
+}
+
+// TestUpdateTotals_Idempotent tests that calling UpdateTotals() multiple times
+// produces the same result (fixes the accumulation bug)
+func TestUpdateTotals_Idempotent(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+			{Total: decimal.NewFromFloat(200.00)},
+		},
+		TradeTaxes: []TradeTax{
+			{CalculatedAmount: decimal.NewFromFloat(57.00)},
+		},
+	}
+
+	// Call UpdateTotals() first time
+	inv.UpdateTotals()
+	firstLineTotal := inv.LineTotal
+	firstTaxTotal := inv.TaxTotal
+	firstGrandTotal := inv.GrandTotal
+
+	// Call UpdateTotals() second time
+	inv.UpdateTotals()
+
+	// Results should be identical
+	if !inv.LineTotal.Equal(firstLineTotal) {
+		t.Errorf("Second call: LineTotal = %s, want %s (should be idempotent)",
+			inv.LineTotal, firstLineTotal)
+	}
+
+	if !inv.TaxTotal.Equal(firstTaxTotal) {
+		t.Errorf("Second call: TaxTotal = %s, want %s (should be idempotent)",
+			inv.TaxTotal, firstTaxTotal)
+	}
+
+	if !inv.GrandTotal.Equal(firstGrandTotal) {
+		t.Errorf("Second call: GrandTotal = %s, want %s (should be idempotent)",
+			inv.GrandTotal, firstGrandTotal)
+	}
+
+	// Call UpdateTotals() third time to be sure
+	inv.UpdateTotals()
+
+	if !inv.LineTotal.Equal(firstLineTotal) {
+		t.Errorf("Third call: LineTotal = %s, want %s (should be idempotent)",
+			inv.LineTotal, firstLineTotal)
+	}
+}
+
+// TestUpdateTotals_ComprehensiveScenario tests all business rules together
+// with a realistic invoice scenario
+func TestUpdateTotals_ComprehensiveScenario(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(500.00)},  // Line 1
+			{Total: decimal.NewFromFloat(300.00)},  // Line 2
+			{Total: decimal.NewFromFloat(200.00)},  // Line 3
+		},
+		TradeTaxes: []TradeTax{
+			{CalculatedAmount: decimal.NewFromFloat(152.00)}, // 19% VAT on 800 basis
+		},
+		AllowanceTotal: decimal.NewFromFloat(250.00), // Document discount
+		ChargeTotal:    decimal.NewFromFloat(50.00),  // Shipping charge
+		TotalPrepaid:   decimal.NewFromFloat(100.00), // Partial payment
+		RoundingAmount: decimal.NewFromFloat(0.05),   // Rounding
+	}
+
+	inv.UpdateTotals()
+
+	// BR-CO-10: LineTotal = 500 + 300 + 200 = 1000
+	expectedLineTotal := decimal.NewFromFloat(1000.00)
+	if !inv.LineTotal.Equal(expectedLineTotal) {
+		t.Errorf("LineTotal = %s, want %s (BR-CO-10)", inv.LineTotal, expectedLineTotal)
+	}
+
+	// TaxTotal = 152 (from TradeTaxes)
+	expectedTaxTotal := decimal.NewFromFloat(152.00)
+	if !inv.TaxTotal.Equal(expectedTaxTotal) {
+		t.Errorf("TaxTotal = %s, want %s", inv.TaxTotal, expectedTaxTotal)
+	}
+
+	// BR-CO-13: TaxBasisTotal = 1000 - 250 + 50 = 800
+	expectedTaxBasisTotal := decimal.NewFromFloat(800.00)
+	if !inv.TaxBasisTotal.Equal(expectedTaxBasisTotal) {
+		t.Errorf("TaxBasisTotal = %s, want %s (BR-CO-13)", inv.TaxBasisTotal, expectedTaxBasisTotal)
+	}
+
+	// BR-CO-15: GrandTotal = 800 + 152 = 952
+	expectedGrandTotal := decimal.NewFromFloat(952.00)
+	if !inv.GrandTotal.Equal(expectedGrandTotal) {
+		t.Errorf("GrandTotal = %s, want %s (BR-CO-15)", inv.GrandTotal, expectedGrandTotal)
+	}
+
+	// BR-CO-16: DuePayableAmount = 952 - 100 + 0.05 = 852.05
+	expectedDuePayableAmount := decimal.NewFromFloat(852.05)
+	if !inv.DuePayableAmount.Equal(expectedDuePayableAmount) {
+		t.Errorf("DuePayableAmount = %s, want %s (BR-CO-16)", inv.DuePayableAmount, expectedDuePayableAmount)
+	}
+}
+
+// TestUpdateTotals_ZeroValues tests that UpdateTotals works correctly with zero values
+func TestUpdateTotals_ZeroValues(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{},
+		TradeTaxes:   []TradeTax{},
+	}
+
+	inv.UpdateTotals()
+
+	if !inv.LineTotal.IsZero() {
+		t.Errorf("LineTotal = %s, want 0", inv.LineTotal)
+	}
+
+	if !inv.TaxTotal.IsZero() {
+		t.Errorf("TaxTotal = %s, want 0", inv.TaxTotal)
+	}
+
+	if !inv.TaxBasisTotal.IsZero() {
+		t.Errorf("TaxBasisTotal = %s, want 0", inv.TaxBasisTotal)
+	}
+
+	if !inv.GrandTotal.IsZero() {
+		t.Errorf("GrandTotal = %s, want 0", inv.GrandTotal)
+	}
+
+	if !inv.DuePayableAmount.IsZero() {
+		t.Errorf("DuePayableAmount = %s, want 0", inv.DuePayableAmount)
+	}
+}

--- a/check.go
+++ b/check.go
@@ -565,7 +565,7 @@ func (inv *Invoice) checkOther() {
 func (inv *Invoice) checkBRO() {
 	var sum decimal.Decimal
 	// BR-CO-10 Gesamtsummen auf Dokumentenebene
-	// Der Inhalt des Elementes „Sum of Invoice line net amount“ (BT-106) entspricht der Summe aller Inhalte der Elemente „Invoice line net amount“
+	// Der Inhalt des Elementes "Sum of Invoice line net amount" (BT-106) entspricht der Summe aller Inhalte der Elemente "Invoice line net amount"
 	// (BT-131).
 	sum = decimal.Zero
 	for _, line := range inv.InvoiceLines {
@@ -573,6 +573,30 @@ func (inv *Invoice) checkBRO() {
 	}
 	if !inv.LineTotal.Equal(sum) {
 		inv.Violations = append(inv.Violations, SemanticError{Rule: "BR-CO-10", InvFields: []string{"BT-106", "BT-131"}, Text: fmt.Sprintf("Line total %s does not match sum of invoice lines %s", inv.LineTotal.String(), sum.String())})
+	}
+
+	// BR-CO-13 Gesamtsummen auf Dokumentenebene
+	// Der Inhalt des Elementes "Invoice total amount without VAT" (BT-109) entspricht der Summe aus "Sum of Invoice line net amount"
+	// (BT-106) abzüglich "Sum of allowances on document level" (BT-107) zuzüglich "Sum of charges on document level" (BT-108).
+	expectedTaxBasisTotal := inv.LineTotal.Sub(inv.AllowanceTotal).Add(inv.ChargeTotal)
+	if !inv.TaxBasisTotal.Equal(expectedTaxBasisTotal) {
+		inv.Violations = append(inv.Violations, SemanticError{Rule: "BR-CO-13", InvFields: []string{"BT-109", "BT-106", "BT-107", "BT-108"}, Text: fmt.Sprintf("Tax basis total %s does not match LineTotal - AllowanceTotal + ChargeTotal = %s", inv.TaxBasisTotal.String(), expectedTaxBasisTotal.String())})
+	}
+
+	// BR-CO-15 Gesamtsummen auf Dokumentenebene
+	// Der Inhalt des Elementes "Invoice total amount with VAT" (BT-112) entspricht der Summe aus "Invoice total amount without VAT"
+	// (BT-109) und "Invoice total VAT amount" (BT-110).
+	expectedGrandTotal := inv.TaxBasisTotal.Add(inv.TaxTotal)
+	if !inv.GrandTotal.Equal(expectedGrandTotal) {
+		inv.Violations = append(inv.Violations, SemanticError{Rule: "BR-CO-15", InvFields: []string{"BT-112", "BT-109", "BT-110"}, Text: fmt.Sprintf("Grand total %s does not match TaxBasisTotal + TaxTotal = %s", inv.GrandTotal.String(), expectedGrandTotal.String())})
+	}
+
+	// BR-CO-16 Gesamtsummen auf Dokumentenebene
+	// Der Inhalt des Elementes "Amount due for payment" (BT-115) entspricht der Summe aus "Invoice total amount with VAT" (BT-112)
+	// abzüglich "Paid amount" (BT-113) zuzüglich "Rounding amount" (BT-114).
+	expectedDuePayableAmount := inv.GrandTotal.Sub(inv.TotalPrepaid).Add(inv.RoundingAmount)
+	if !inv.DuePayableAmount.Equal(expectedDuePayableAmount) {
+		inv.Violations = append(inv.Violations, SemanticError{Rule: "BR-CO-16", InvFields: []string{"BT-115", "BT-112", "BT-113", "BT-114"}, Text: fmt.Sprintf("Due payable amount %s does not match GrandTotal - TotalPrepaid + RoundingAmount = %s", inv.DuePayableAmount.String(), expectedDuePayableAmount.String())})
 	}
 
 }

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,243 @@
+package einvoice
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestCheckBRO_BR_CO_10_Valid tests that BR-CO-10 validation passes when LineTotal matches sum of invoice lines
+func TestCheckBRO_BR_CO_10_Valid(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+			{Total: decimal.NewFromFloat(200.00)},
+		},
+		LineTotal: decimal.NewFromFloat(300.00),
+	}
+
+	inv.checkBRO()
+
+	// Check that no BR-CO-10 violations were added
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-10" {
+			t.Errorf("Expected no BR-CO-10 violation, but got: %s", v.Text)
+		}
+	}
+}
+
+// TestCheckBRO_BR_CO_10_Invalid tests that BR-CO-10 violation is detected when LineTotal doesn't match
+func TestCheckBRO_BR_CO_10_Invalid(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+			{Total: decimal.NewFromFloat(200.00)},
+		},
+		LineTotal: decimal.NewFromFloat(250.00), // Wrong value
+	}
+
+	inv.checkBRO()
+
+	// Check that BR-CO-10 violation was added
+	found := false
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-10" {
+			found = true
+			if len(v.InvFields) != 2 || v.InvFields[0] != "BT-106" || v.InvFields[1] != "BT-131" {
+				t.Errorf("BR-CO-10 violation has incorrect InvFields: %v", v.InvFields)
+			}
+		}
+	}
+	if !found {
+		t.Error("Expected BR-CO-10 violation, but none was found")
+	}
+}
+
+// TestCheckBRO_BR_CO_13_Valid tests that BR-CO-13 validation passes when TaxBasisTotal is correct
+func TestCheckBRO_BR_CO_13_Valid(t *testing.T) {
+	inv := &Invoice{
+		LineTotal:      decimal.NewFromFloat(1000.00),
+		AllowanceTotal: decimal.NewFromFloat(150.00),
+		ChargeTotal:    decimal.NewFromFloat(50.00),
+		TaxBasisTotal:  decimal.NewFromFloat(900.00), // 1000 - 150 + 50
+	}
+
+	inv.checkBRO()
+
+	// Check that no BR-CO-13 violations were added
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-13" {
+			t.Errorf("Expected no BR-CO-13 violation, but got: %s", v.Text)
+		}
+	}
+}
+
+// TestCheckBRO_BR_CO_13_Invalid tests that BR-CO-13 violation is detected when TaxBasisTotal is wrong
+func TestCheckBRO_BR_CO_13_Invalid(t *testing.T) {
+	inv := &Invoice{
+		LineTotal:      decimal.NewFromFloat(1000.00),
+		AllowanceTotal: decimal.NewFromFloat(150.00),
+		ChargeTotal:    decimal.NewFromFloat(50.00),
+		TaxBasisTotal:  decimal.NewFromFloat(1000.00), // Wrong: should be 900
+	}
+
+	inv.checkBRO()
+
+	// Check that BR-CO-13 violation was added
+	found := false
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-13" {
+			found = true
+			expectedFields := []string{"BT-109", "BT-106", "BT-107", "BT-108"}
+			if len(v.InvFields) != len(expectedFields) {
+				t.Errorf("BR-CO-13 violation has incorrect number of InvFields: got %v, want %v", v.InvFields, expectedFields)
+			}
+		}
+	}
+	if !found {
+		t.Error("Expected BR-CO-13 violation, but none was found")
+	}
+}
+
+// TestCheckBRO_BR_CO_15_Valid tests that BR-CO-15 validation passes when GrandTotal is correct
+func TestCheckBRO_BR_CO_15_Valid(t *testing.T) {
+	inv := &Invoice{
+		TaxBasisTotal: decimal.NewFromFloat(900.00),
+		TaxTotal:      decimal.NewFromFloat(171.00),
+		GrandTotal:    decimal.NewFromFloat(1071.00), // 900 + 171
+	}
+
+	inv.checkBRO()
+
+	// Check that no BR-CO-15 violations were added
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-15" {
+			t.Errorf("Expected no BR-CO-15 violation, but got: %s", v.Text)
+		}
+	}
+}
+
+// TestCheckBRO_BR_CO_15_Invalid tests that BR-CO-15 violation is detected when GrandTotal is wrong
+func TestCheckBRO_BR_CO_15_Invalid(t *testing.T) {
+	inv := &Invoice{
+		TaxBasisTotal: decimal.NewFromFloat(900.00),
+		TaxTotal:      decimal.NewFromFloat(171.00),
+		GrandTotal:    decimal.NewFromFloat(1000.00), // Wrong: should be 1071
+	}
+
+	inv.checkBRO()
+
+	// Check that BR-CO-15 violation was added
+	found := false
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-15" {
+			found = true
+			expectedFields := []string{"BT-112", "BT-109", "BT-110"}
+			if len(v.InvFields) != len(expectedFields) {
+				t.Errorf("BR-CO-15 violation has incorrect number of InvFields: got %v, want %v", v.InvFields, expectedFields)
+			}
+		}
+	}
+	if !found {
+		t.Error("Expected BR-CO-15 violation, but none was found")
+	}
+}
+
+// TestCheckBRO_BR_CO_16_Valid tests that BR-CO-16 validation passes when DuePayableAmount is correct
+func TestCheckBRO_BR_CO_16_Valid(t *testing.T) {
+	inv := &Invoice{
+		GrandTotal:       decimal.NewFromFloat(1071.00),
+		TotalPrepaid:     decimal.NewFromFloat(100.00),
+		RoundingAmount:   decimal.NewFromFloat(0.05),
+		DuePayableAmount: decimal.NewFromFloat(971.05), // 1071 - 100 + 0.05
+	}
+
+	inv.checkBRO()
+
+	// Check that no BR-CO-16 violations were added
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-16" {
+			t.Errorf("Expected no BR-CO-16 violation, but got: %s", v.Text)
+		}
+	}
+}
+
+// TestCheckBRO_BR_CO_16_Invalid tests that BR-CO-16 violation is detected when DuePayableAmount is wrong
+func TestCheckBRO_BR_CO_16_Invalid(t *testing.T) {
+	inv := &Invoice{
+		GrandTotal:       decimal.NewFromFloat(1071.00),
+		TotalPrepaid:     decimal.NewFromFloat(100.00),
+		RoundingAmount:   decimal.NewFromFloat(0.05),
+		DuePayableAmount: decimal.NewFromFloat(971.00), // Wrong: should be 971.05
+	}
+
+	inv.checkBRO()
+
+	// Check that BR-CO-16 violation was added
+	found := false
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-16" {
+			found = true
+			expectedFields := []string{"BT-115", "BT-112", "BT-113", "BT-114"}
+			if len(v.InvFields) != len(expectedFields) {
+				t.Errorf("BR-CO-16 violation has incorrect number of InvFields: got %v, want %v", v.InvFields, expectedFields)
+			}
+		}
+	}
+	if !found {
+		t.Error("Expected BR-CO-16 violation, but none was found")
+	}
+}
+
+// TestCheckBRO_MultipleViolations tests detection of multiple violations at once
+func TestCheckBRO_MultipleViolations(t *testing.T) {
+	inv := &Invoice{
+		InvoiceLines: []InvoiceLine{
+			{Total: decimal.NewFromFloat(100.00)},
+			{Total: decimal.NewFromFloat(200.00)},
+		},
+		LineTotal:        decimal.NewFromFloat(250.00),  // Wrong: should be 300 (BR-CO-10)
+		AllowanceTotal:   decimal.NewFromFloat(50.00),
+		ChargeTotal:      decimal.NewFromFloat(10.00),
+		TaxBasisTotal:    decimal.NewFromFloat(250.00),  // Wrong: should be 210 (BR-CO-13)
+		TaxTotal:         decimal.NewFromFloat(47.50),
+		GrandTotal:       decimal.NewFromFloat(300.00),  // Wrong: should be 257.50 (BR-CO-15)
+		TotalPrepaid:     decimal.NewFromFloat(50.00),
+		RoundingAmount:   decimal.NewFromFloat(0.50),
+		DuePayableAmount: decimal.NewFromFloat(250.00),  // Wrong: should be 250.50 (BR-CO-16)
+	}
+
+	inv.checkBRO()
+
+	// Check that all four violations were detected
+	violations := make(map[string]bool)
+	for _, v := range inv.Violations {
+		violations[v.Rule] = true
+	}
+
+	expectedViolations := []string{"BR-CO-10", "BR-CO-13", "BR-CO-15", "BR-CO-16"}
+	for _, rule := range expectedViolations {
+		if !violations[rule] {
+			t.Errorf("Expected %s violation, but it was not found", rule)
+		}
+	}
+}
+
+// TestCheckBRO_WithNegativeRounding tests BR-CO-16 with negative rounding amount
+func TestCheckBRO_BR_CO_16_NegativeRounding(t *testing.T) {
+	inv := &Invoice{
+		GrandTotal:       decimal.NewFromFloat(119.00),
+		TotalPrepaid:     decimal.NewFromFloat(50.00),
+		RoundingAmount:   decimal.NewFromFloat(-0.14),
+		DuePayableAmount: decimal.NewFromFloat(68.86), // 119 - 50 + (-0.14)
+	}
+
+	inv.checkBRO()
+
+	// Check that no BR-CO-16 violations were added
+	for _, v := range inv.Violations {
+		if v.Rule == "BR-CO-16" {
+			t.Errorf("Expected no BR-CO-16 violation with negative rounding, but got: %s", v.Text)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in the `UpdateTotals()` function and adds comprehensive validation for EN 16931 business rules BR-CO-13, BR-CO-15, and BR-CO-16.

## Bugs Fixed

### 1. Bug #1 (Critical): Incorrect LineTotal calculation
- **Issue**: `UpdateTotals()` was iterating over `TradeTaxes` instead of `InvoiceLines` to calculate `LineTotal`
- **Fix**: Now correctly sums invoice line totals (BT-131) per BR-CO-10
- **Impact**: LineTotal was being calculated from tax basis amounts instead of actual line amounts

### 2. Bug #2 (High): Missing allowances and charges
- **Issue**: Document-level allowances and charges were ignored in TaxBasisTotal calculation
- **Fix**: Now properly applies `AllowanceTotal` and `ChargeTotal` per BR-CO-13
- **Impact**: TaxBasisTotal was incorrect when document-level allowances/charges were present

### 3. Bug #3 (High): Missing RoundingAmount
- **Issue**: `RoundingAmount` was not included in `DuePayableAmount` calculation
- **Fix**: Now includes `RoundingAmount` per BR-CO-16
- **Impact**: DuePayableAmount was incorrect when rounding was applied

### 4. Idempotent behavior
- **Issue**: Calling `UpdateTotals()` multiple times would accumulate values
- **Fix**: Reset totals to zero before recalculating
- **Impact**: Function is now safe to call multiple times

## Validation Checks Added

Added validation in `checkBRO()` for:
- **BR-CO-13**: `TaxBasisTotal = LineTotal - AllowanceTotal + ChargeTotal`
- **BR-CO-15**: `GrandTotal = TaxBasisTotal + TaxTotal`
- **BR-CO-16**: `DuePayableAmount = GrandTotal - TotalPrepaid + RoundingAmount`

Also replaced German quotation marks „" with standard ASCII quotes "" in comments.

## Test Coverage

### calculate_test.go (6 tests)
- Basic calculation with multiple invoice lines
- Document-level allowances and charges
- Rounding amounts
- Idempotent behavior (multiple calls)
- Comprehensive scenario combining all features
- Zero values edge case

### check_test.go (10 tests)
- Valid/invalid tests for BR-CO-10, BR-CO-13, BR-CO-15, BR-CO-16
- Multiple violations detection
- Edge cases (negative rounding)

All tests pass ✓

## Specification References

This implementation follows EN 16931 business rules:
- BR-CO-10: Sum of Invoice line net amount
- BR-CO-13: Invoice total amount without VAT
- BR-CO-15: Invoice total amount with VAT
- BR-CO-16: Amount due for payment

## Related Issues

Addresses issues #1, #2, and #3 documented in BUG_REPORT.md