### PR TITLE
Fix parser.go issues: error handling, duplicate code, missing field

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1,6 +1,7 @@
 package einvoice_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/speedata/einvoice"
@@ -19,5 +20,124 @@ func TestSimple(t *testing.T) {
 	}
 	if got := inv.InvoiceNumber; got != expected.InvoiceNumber {
 		t.Errorf("invoice number got %s, expected %s\n", got, expected.InvoiceNumber)
+	}
+}
+
+func TestInvalidDecimalValue(t *testing.T) {
+	t.Parallel()
+
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>INV-001</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime><udt:DateTimeString format="102">20240101</udt:DateTimeString></ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerTradeParty><ram:Name>Buyer</ram:Name></ram:BuyerTradeParty>
+      <ram:SellerTradeParty><ram:Name>Seller</ram:Name></ram:SellerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery/>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>INVALID</ram:LineTotalAmount>
+        <ram:TaxBasisTotalAmount>100.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount>19.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>119.00</ram:GrandTotalAmount>
+        <ram:DuePayableAmount>119.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>`
+
+	_, err := einvoice.ParseReader(strings.NewReader(xml))
+	if err == nil {
+		t.Error("expected error for invalid decimal value, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid decimal value") {
+		t.Errorf("expected error message to contain 'invalid decimal value', got: %v", err)
+	}
+}
+
+func TestCountrySubDivisionNameParsing(t *testing.T) {
+	t.Parallel()
+
+	xml := `<?xml version="1.0" encoding="UTF-8"?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100"
+                          xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100"
+                          xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+  <rsm:ExchangedDocumentContext>
+    <ram:GuidelineSpecifiedDocumentContextParameter>
+      <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+    </ram:GuidelineSpecifiedDocumentContextParameter>
+  </rsm:ExchangedDocumentContext>
+  <rsm:ExchangedDocument>
+    <ram:ID>INV-001</ram:ID>
+    <ram:TypeCode>380</ram:TypeCode>
+    <ram:IssueDateTime><udt:DateTimeString format="102">20240101</udt:DateTimeString></ram:IssueDateTime>
+  </rsm:ExchangedDocument>
+  <rsm:SupplyChainTradeTransaction>
+    <ram:ApplicableHeaderTradeAgreement>
+      <ram:BuyerTradeParty>
+        <ram:Name>Buyer Company</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>12345</ram:PostcodeCode>
+          <ram:LineOne>123 Main St</ram:LineOne>
+          <ram:CityName>Berlin</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+          <ram:CountrySubDivisionName>Brandenburg</ram:CountrySubDivisionName>
+        </ram:PostalTradeAddress>
+      </ram:BuyerTradeParty>
+      <ram:SellerTradeParty>
+        <ram:Name>Seller Company</ram:Name>
+        <ram:PostalTradeAddress>
+          <ram:PostcodeCode>54321</ram:PostcodeCode>
+          <ram:LineOne>456 Oak Ave</ram:LineOne>
+          <ram:CityName>Munich</ram:CityName>
+          <ram:CountryID>DE</ram:CountryID>
+          <ram:CountrySubDivisionName>Bavaria</ram:CountrySubDivisionName>
+        </ram:PostalTradeAddress>
+      </ram:SellerTradeParty>
+    </ram:ApplicableHeaderTradeAgreement>
+    <ram:ApplicableHeaderTradeDelivery/>
+    <ram:ApplicableHeaderTradeSettlement>
+      <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+      <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        <ram:LineTotalAmount>100.00</ram:LineTotalAmount>
+        <ram:TaxBasisTotalAmount>100.00</ram:TaxBasisTotalAmount>
+        <ram:TaxTotalAmount>19.00</ram:TaxTotalAmount>
+        <ram:GrandTotalAmount>119.00</ram:GrandTotalAmount>
+        <ram:DuePayableAmount>119.00</ram:DuePayableAmount>
+      </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+    </ram:ApplicableHeaderTradeSettlement>
+  </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>`
+
+	inv, err := einvoice.ParseReader(strings.NewReader(xml))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if inv.Buyer.PostalAddress == nil {
+		t.Fatal("buyer postal address is nil")
+	}
+	if got := inv.Buyer.PostalAddress.CountrySubDivisionName; got != "Brandenburg" {
+		t.Errorf("buyer CountrySubDivisionName: got %q, want %q", got, "Brandenburg")
+	}
+
+	if inv.Seller.PostalAddress == nil {
+		t.Fatal("seller postal address is nil")
+	}
+	if got := inv.Seller.PostalAddress.CountrySubDivisionName; got != "Bavaria" {
+		t.Errorf("seller CountrySubDivisionName: got %q, want %q", got, "Bavaria")
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes three bugs in `parser.go` as identified in the bug report:

1. **Silent error handling in `getDecimal`** (Bug #9)
2. **Duplicate assignment** (Bug #10)  
3. **Missing `CountrySubDivisionName` parsing** (Bug #11)

## Changes

### 1. Fix silent error handling in getDecimal (parser.go:78-88)

**Problem:** The `getDecimal` function silently ignored errors from `decimal.NewFromString()`, causing malformed decimal values to be parsed as zero without warning.

**Fix:**
- Changed `getDecimal` to return `(decimal.Decimal, error)`
- Empty strings return `decimal.Zero` (for optional fields)
- Invalid values return descriptive errors
- Updated all 30+ call sites to properly handle errors

**Test:** Added `TestInvalidDecimalValue` to verify error handling

### 2. Remove duplicate assignment (parser.go:162)

**Problem:** `spt.Description` was assigned twice at lines 155 and 162.

**Fix:** Removed the redundant second assignment.

### 3. Add missing CountrySubDivisionName parsing (parser.go:68)

**Problem:** The `PostalAddress` struct has a `CountrySubDivisionName` field (BT-39, BT-54, BT-68, BT-79) but it wasn't being parsed from XML.

**Fix:** Added parsing of `ram:PostalTradeAddress/ram:CountrySubDivisionName` in the `parseParty` function.

**Test:** Added `TestCountrySubDivisionNameParsing` to verify parsing for buyer and seller addresses.

## Testing

All existing tests pass, plus two new tests:
- `TestInvalidDecimalValue`: Verifies proper error handling for malformed decimal values
- `TestCountrySubDivisionNameParsing`: Verifies CountrySubDivisionName field parsing

```
go test -v
PASS
```

## Spec Compliance

These fixes improve spec compliance by:
- Catching malformed data earlier (invalid decimals)
- Supporting BT-39, BT-54, BT-68, BT-79 fields (CountrySubDivisionName)