### PR TITLE
Refactor tests to use same-package (white-box) testing

### DIFF
--- a/einvoice_test.go
+++ b/einvoice_test.go
@@ -1,57 +1,56 @@
-package einvoice_test
+package einvoice
 
 import (
 	"os"
 	"time"
 
 	"github.com/shopspring/decimal"
-	"github.com/speedata/einvoice"
 )
 
 func ExampleInvoice_Write() {
 	fixedDate, _ := time.Parse("02.01.2006", "31.12.2025")
 	fourteenDays := time.Hour * 24 * 14
-	inv := einvoice.Invoice{
+	inv := Invoice{
 		InvoiceNumber:       "1234",
 		InvoiceTypeCode:     380,
-		Profile:             einvoice.CProfileEN16931,
+		Profile:             CProfileEN16931,
 		InvoiceDate:         fixedDate,
 		OccurrenceDateTime:  fixedDate.Add(-fourteenDays),
 		InvoiceCurrencyCode: "EUR",
 		TaxCurrencyCode:     "EUR",
-		Notes: []einvoice.Note{{
+		Notes: []Note{{
 			Text: "Some text",
 		}},
-		Seller: einvoice.Party{
+		Seller: Party{
 			Name:              "Company name",
 			VATaxRegistration: "DE123456",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Line one",
 				Line2:        "Line two",
 				City:         "City",
 				PostcodeCode: "12345",
 				CountryID:    "DE",
 			},
-			DefinedTradeContact: []einvoice.DefinedTradeContact{{
+			DefinedTradeContact: []DefinedTradeContact{{
 				PersonName: "Jon Doe",
 				EMail:      "doe@example.com",
 			}},
 		},
-		Buyer: einvoice.Party{
+		Buyer: Party{
 			Name: "Buyer",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Buyer line 1",
 				Line2:        "Buyer line 2",
 				City:         "Buyercity",
 				PostcodeCode: "33441",
 				CountryID:    "FR",
 			},
-			DefinedTradeContact: []einvoice.DefinedTradeContact{{
+			DefinedTradeContact: []DefinedTradeContact{{
 				PersonName: "Buyer Person",
 			}},
 			VATaxRegistration: "FR4441112",
 		},
-		PaymentMeans: []einvoice.PaymentMeans{
+		PaymentMeans: []PaymentMeans{
 			{
 				TypeCode:                                      30,
 				PayeePartyCreditorFinancialAccountIBAN:        "DE123455958381",
@@ -59,10 +58,10 @@ func ExampleInvoice_Write() {
 				PayeeSpecifiedCreditorFinancialInstitutionBIC: "BANKDEFXXX",
 			},
 		},
-		SpecifiedTradePaymentTerms: []einvoice.SpecifiedTradePaymentTerms{{
+		SpecifiedTradePaymentTerms: []SpecifiedTradePaymentTerms{{
 			DueDate: fixedDate.Add(fourteenDays),
 		}},
-		InvoiceLines: []einvoice.InvoiceLine{
+		InvoiceLines: []InvoiceLine{
 			{
 				LineID:                   "1",
 				ItemName:                 "Item name one",

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,21 +1,19 @@
-package einvoice_test
+package einvoice
 
 import (
 	"strings"
 	"testing"
-
-	"github.com/speedata/einvoice"
 )
 
 func TestSimple(t *testing.T) {
 	t.Parallel()
 
-	inv, err := einvoice.ParseXMLFile("testcases/zugferd_2p0_EN16931_1_Teilrechnung.xml")
+	inv, err := ParseXMLFile("testcases/zugferd_2p0_EN16931_1_Teilrechnung.xml")
 	if err != nil {
 		t.Error(err)
 	}
 
-	expected := einvoice.Invoice{
+	expected := Invoice{
 		InvoiceNumber: "471102",
 	}
 	if got := inv.InvoiceNumber; got != expected.InvoiceNumber {
@@ -59,7 +57,7 @@ func TestInvalidDecimalValue(t *testing.T) {
   </rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>`
 
-	_, err := einvoice.ParseReader(strings.NewReader(xml))
+	_, err := ParseReader(strings.NewReader(xml))
 	if err == nil {
 		t.Error("expected error for invalid decimal value, got nil")
 	}
@@ -122,7 +120,7 @@ func TestCountrySubDivisionNameParsing(t *testing.T) {
   </rsm:SupplyChainTradeTransaction>
 </rsm:CrossIndustryInvoice>`
 
-	inv, err := einvoice.ParseReader(strings.NewReader(xml))
+	inv, err := ParseReader(strings.NewReader(xml))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,4 +1,4 @@
-package einvoice_test
+package einvoice
 
 import (
 	"bytes"
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
-	"github.com/speedata/einvoice"
 )
 
 // TestWrite_PayeeTradeParty tests that PayeeTradeParty is written with correct XML structure
@@ -17,25 +16,25 @@ func TestWrite_PayeeTradeParty(t *testing.T) {
 
 	fixedDate, _ := time.Parse("02.01.2006", "31.12.2025")
 
-	inv := einvoice.Invoice{
+	inv := Invoice{
 		InvoiceNumber:       "TEST-001",
 		InvoiceTypeCode:     380,
-		Profile:             einvoice.CProfileEN16931,
+		Profile:             CProfileEN16931,
 		InvoiceDate:         fixedDate,
 		InvoiceCurrencyCode: "EUR",
-		Seller: einvoice.Party{
+		Seller: Party{
 			Name:              "Seller Company",
 			VATaxRegistration: "DE123456",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Seller Street 1",
 				City:         "Berlin",
 				PostcodeCode: "10115",
 				CountryID:    "DE",
 			},
 		},
-		Buyer: einvoice.Party{
+		Buyer: Party{
 			Name: "Buyer Company",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Buyer Street 1",
 				City:         "Paris",
 				PostcodeCode: "75001",
@@ -43,17 +42,17 @@ func TestWrite_PayeeTradeParty(t *testing.T) {
 			},
 		},
 		// BG-10: PayeeTradeParty - different from seller
-		PayeeTradeParty: &einvoice.Party{
+		PayeeTradeParty: &Party{
 			Name:              "Payment Receiver Inc",
 			VATaxRegistration: "DE789012",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Payee Street 1",
 				City:         "Munich",
 				PostcodeCode: "80331",
 				CountryID:    "DE",
 			},
 		},
-		InvoiceLines: []einvoice.InvoiceLine{
+		InvoiceLines: []InvoiceLine{
 			{
 				LineID:                   "1",
 				ItemName:                 "Test Item",
@@ -123,33 +122,33 @@ func TestWrite_MultiCurrencyTaxTotal(t *testing.T) {
 
 	fixedDate, _ := time.Parse("02.01.2006", "31.12.2025")
 
-	inv := einvoice.Invoice{
+	inv := Invoice{
 		InvoiceNumber:       "MULTI-CURR-001",
 		InvoiceTypeCode:     380,
-		Profile:             einvoice.CProfileEN16931,
+		Profile:             CProfileEN16931,
 		InvoiceDate:         fixedDate,
-		InvoiceCurrencyCode: "USD",        // BT-5: Invoice in USD
-		TaxCurrencyCode:     "EUR",        // BT-6: Tax accounting in EUR
-		Seller: einvoice.Party{
+		InvoiceCurrencyCode: "USD", // BT-5: Invoice in USD
+		TaxCurrencyCode:     "EUR", // BT-6: Tax accounting in EUR
+		Seller: Party{
 			Name:              "Seller Company",
 			VATaxRegistration: "DE123456",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Seller Street 1",
 				City:         "Berlin",
 				PostcodeCode: "10115",
 				CountryID:    "DE",
 			},
 		},
-		Buyer: einvoice.Party{
+		Buyer: Party{
 			Name: "Buyer Company",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Buyer Street 1",
 				City:         "New York",
 				PostcodeCode: "10001",
 				CountryID:    "US",
 			},
 		},
-		InvoiceLines: []einvoice.InvoiceLine{
+		InvoiceLines: []InvoiceLine{
 			{
 				LineID:                   "1",
 				ItemName:                 "Test Item",
@@ -210,33 +209,33 @@ func TestWrite_SingleCurrencyTaxTotal(t *testing.T) {
 
 	fixedDate, _ := time.Parse("02.01.2006", "31.12.2025")
 
-	inv := einvoice.Invoice{
+	inv := Invoice{
 		InvoiceNumber:       "SINGLE-CURR-001",
 		InvoiceTypeCode:     380,
-		Profile:             einvoice.CProfileEN16931,
+		Profile:             CProfileEN16931,
 		InvoiceDate:         fixedDate,
-		InvoiceCurrencyCode: "EUR",  // BT-5
-		TaxCurrencyCode:     "EUR",  // BT-6: Same as invoice currency
-		Seller: einvoice.Party{
+		InvoiceCurrencyCode: "EUR", // BT-5
+		TaxCurrencyCode:     "EUR", // BT-6: Same as invoice currency
+		Seller: Party{
 			Name:              "Seller Company",
 			VATaxRegistration: "DE123456",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Seller Street 1",
 				City:         "Berlin",
 				PostcodeCode: "10115",
 				CountryID:    "DE",
 			},
 		},
-		Buyer: einvoice.Party{
+		Buyer: Party{
 			Name: "Buyer Company",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Buyer Street 1",
 				City:         "Paris",
 				PostcodeCode: "75001",
 				CountryID:    "FR",
 			},
 		},
-		InvoiceLines: []einvoice.InvoiceLine{
+		InvoiceLines: []InvoiceLine{
 			{
 				LineID:                   "1",
 				ItemName:                 "Test Item",
@@ -280,33 +279,33 @@ func TestWrite_NoTaxCurrencyCode(t *testing.T) {
 
 	fixedDate, _ := time.Parse("02.01.2006", "31.12.2025")
 
-	inv := einvoice.Invoice{
+	inv := Invoice{
 		InvoiceNumber:       "NO-TAX-CURR-001",
 		InvoiceTypeCode:     380,
-		Profile:             einvoice.CProfileEN16931,
+		Profile:             CProfileEN16931,
 		InvoiceDate:         fixedDate,
 		InvoiceCurrencyCode: "EUR",
 		// TaxCurrencyCode not set (empty string)
-		Seller: einvoice.Party{
+		Seller: Party{
 			Name:              "Seller Company",
 			VATaxRegistration: "DE123456",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Seller Street 1",
 				City:         "Berlin",
 				PostcodeCode: "10115",
 				CountryID:    "DE",
 			},
 		},
-		Buyer: einvoice.Party{
+		Buyer: Party{
 			Name: "Buyer Company",
-			PostalAddress: &einvoice.PostalAddress{
+			PostalAddress: &PostalAddress{
 				Line1:        "Buyer Street 1",
 				City:         "Paris",
 				PostcodeCode: "75001",
 				CountryID:    "FR",
 			},
 		},
-		InvoiceLines: []einvoice.InvoiceLine{
+		InvoiceLines: []InvoiceLine{
 			{
 				LineID:                   "1",
 				ItemName:                 "Test Item",


### PR DESCRIPTION
## Summary
- Changed test package from `einvoice_test` to `einvoice` for white-box testing
- Removed redundant package imports and type qualifiers
- Enables direct access to package internals in tests

## Changes
- Updated package declarations in all test files
- Removed `github.com/speedata/einvoice` import from test files
- Removed `einvoice.` prefix from all type references

## Files Modified
- `einvoice_test.go`
- `parser_test.go`
- `writer_test.go`

## Test Plan
- [x] All existing tests pass without modification
- [x] No functional changes to test logic