### PR TITLE
Add CLI tool with validate command (RFC #13 - Phase 1)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,6 +71,45 @@ func dothings() error {
 
 There is a [dedicated example](https://pkg.go.dev/github.com/speedata/einvoice#example-Invoice.Write) in [the documentation](https://pkg.go.dev/github.com/speedata/einvoice).
 
+## Command Line Tool
+
+A CLI tool is available for validating invoices from the command line.
+
+### Installation
+
+```bash
+go install github.com/speedata/einvoice/cmd/einvoice@latest
+```
+
+### Usage
+
+Validate an invoice and display violations in human-readable format:
+
+```bash
+einvoice validate invoice.xml
+```
+
+Output validation results as JSON (useful for automation and CI/CD):
+
+```bash
+einvoice validate --format json invoice.xml
+```
+
+### Exit Codes
+
+- `0` - Invoice is valid (no violations)
+- `1` - Invoice has validation violations
+- `2` - Error occurred (file not found, parse error, etc.)
+
+These exit codes make it easy to integrate the validator into shell scripts and CI/CD pipelines:
+
+```bash
+if einvoice validate invoice.xml; then
+    echo "Invoice is valid!"
+else
+    echo "Validation failed"
+fi
+```
 
 ## Current status
 

--- a/cmd/einvoice/main.go
+++ b/cmd/einvoice/main.go
@@ -1,0 +1,47 @@
+// Command einvoice validates electronic invoices against EN 16931 business rules.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	exitOK         = 0 // Invoice is valid
+	exitViolations = 1 // Invoice has validation violations
+	exitError      = 2 // Error occurred (file not found, parse error, etc.)
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	// Check for subcommand
+	if len(os.Args) < 2 {
+		usage()
+		return exitError
+	}
+
+	subcommand := os.Args[1]
+
+	// Dispatch to subcommand
+	switch subcommand {
+	case "validate":
+		return runValidate(os.Args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown command %q\n", subcommand)
+		usage()
+		return exitError
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Usage: einvoice <command> [options]
+
+Commands:
+  validate    Validate an electronic invoice against EN 16931 business rules
+
+Use "einvoice <command> --help" for more information about a command.
+`)
+}

--- a/cmd/einvoice/main_test.go
+++ b/cmd/einvoice/main_test.go
@@ -1,246 +1,142 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestValidateInvoice(t *testing.T) {
+func TestRun(t *testing.T) {
 	tests := []struct {
-		name          string
-		filename      string
-		wantValid     bool
-		wantError     bool
-		wantViolation bool
+		name     string
+		args     []string
+		wantExit int
 	}{
 		{
-			name:      "valid invoice from testcases",
-			filename:  "../../testcases/zugferd_2p0_EN16931_1_Teilrechnung.xml",
-			wantValid: false, // We don't know if this is valid without checking
-			wantError: false,
+			name:     "no arguments",
+			args:     []string{"einvoice"},
+			wantExit: exitError,
 		},
 		{
-			name:      "non-existent file",
-			filename:  "non_existent_file.xml",
-			wantValid: false,
-			wantError: true,
+			name:     "unknown command",
+			args:     []string{"einvoice", "unknown"},
+			wantExit: exitError,
+		},
+		{
+			name:     "validate command exists",
+			args:     []string{"einvoice", "validate"},
+			wantExit: exitError, // Will fail because no file argument, but tests command exists
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := validateInvoice(tt.filename)
+			// Save original os.Args and restore after test
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
 
-			if tt.wantError {
-				if result.Error == "" {
-					t.Errorf("validateInvoice() expected error, got none")
-				}
-				return
-			}
+			// Capture stderr to suppress output during tests
+			oldStderr := os.Stderr
+			_, w, _ := os.Pipe()
+			os.Stderr = w
 
-			if result.Error != "" {
-				t.Errorf("validateInvoice() unexpected error: %v", result.Error)
-				return
-			}
+			// Set os.Args for the test
+			os.Args = tt.args
 
-			// For valid test case file, just verify we got some result
-			if result.Invoice == nil {
-				t.Errorf("validateInvoice() invoice metadata is nil")
+			exitCode := run()
+
+			w.Close()
+			os.Stderr = oldStderr
+
+			if exitCode != tt.wantExit {
+				t.Errorf("run() exit code = %v, want %v", exitCode, tt.wantExit)
 			}
 		})
 	}
 }
 
-func TestValidateInvoice_MalformedXML(t *testing.T) {
-	// Create a temporary malformed XML file
-	tmpfile, err := os.CreateTemp("", "malformed-*.xml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name())
-
-	if _, err := tmpfile.Write([]byte("<invalid>xml</wrong>")); err != nil {
-		t.Fatal(err)
-	}
-	tmpfile.Close()
-
-	result := validateInvoice(tmpfile.Name())
-
-	if result.Error == "" {
-		t.Error("validateInvoice() expected error for malformed XML, got none")
-	}
-
-	if !strings.Contains(result.Error, "parse") {
-		t.Errorf("validateInvoice() error should mention parsing, got: %v", result.Error)
-	}
-}
-
-func TestOutputJSON(t *testing.T) {
-	result := Result{
-		File:  "test.xml",
-		Valid: false,
-		Invoice: &InvoiceRef{
-			Number: "INV-001",
-			Date:   "2024-01-15",
-			Total:  "1000.00",
-		},
-		Violations: []Violation{
-			{Rule: "BR-1", Text: "violation 1"},
-			{Rule: "BR-2", Text: "violation 2"},
-		},
-	}
-
-	// Capture stdout
-	oldStdout := os.Stdout
+func TestUsage(t *testing.T) {
+	// Capture stderr
+	oldStderr := os.Stderr
 	r, w, _ := os.Pipe()
-	os.Stdout = w
+	os.Stderr = w
 
-	outputJSON(result)
+	usage()
 
 	w.Close()
-	os.Stdout = oldStdout
+	os.Stderr = oldStderr
 
 	var buf strings.Builder
 	io.Copy(&buf, r)
 	output := buf.String()
 
-	// Verify it's valid JSON
-	var decoded Result
-	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
-		t.Errorf("outputJSON() produced invalid JSON: %v", err)
+	// Verify usage output contains expected elements
+	expectedStrings := []string{
+		"Usage:",
+		"einvoice",
+		"command",
+		"validate",
 	}
 
-	// Verify content
-	if decoded.File != "test.xml" {
-		t.Errorf("outputJSON() file = %v, want %v", decoded.File, "test.xml")
-	}
-	if decoded.Valid != false {
-		t.Errorf("outputJSON() valid = %v, want %v", decoded.Valid, false)
-	}
-	if len(decoded.Violations) != 2 {
-		t.Errorf("outputJSON() violations count = %v, want %v", len(decoded.Violations), 2)
+	for _, expected := range expectedStrings {
+		if !strings.Contains(output, expected) {
+			t.Errorf("usage() output missing %q, got: %v", expected, output)
+		}
 	}
 }
 
-func TestOutputText(t *testing.T) {
+func TestSubcommandDispatch(t *testing.T) {
 	tests := []struct {
-		name       string
-		result     Result
-		wantStderr bool
-		wantOutput string
+		name        string
+		args        []string
+		wantExit    int
+		wantStderr  string
 	}{
 		{
-			name: "valid invoice",
-			result: Result{
-				File:  "test.xml",
-				Valid: true,
-				Invoice: &InvoiceRef{
-					Number: "INV-001",
-				},
-			},
-			wantStderr: false,
-			wantOutput: "✓ Invoice INV-001 is valid",
+			name:       "dispatch to validate",
+			args:       []string{"einvoice", "validate"},
+			wantExit:   exitError, // No file provided
+			wantStderr: "Usage: einvoice validate",
 		},
 		{
-			name: "invalid invoice with violations",
-			result: Result{
-				File:  "test.xml",
-				Valid: false,
-				Invoice: &InvoiceRef{
-					Number: "INV-002",
-				},
-				Violations: []Violation{
-					{Rule: "BR-1", Text: "violation"},
-				},
-			},
-			wantStderr: false,
-			wantOutput: "✗ Invoice INV-002 has 1 violation(s):",
-		},
-		{
-			name: "error case",
-			result: Result{
-				File:  "test.xml",
-				Error: "file not found",
-			},
-			wantStderr: true,
-			wantOutput: "Error: file not found",
+			name:       "unknown command shows error",
+			args:       []string{"einvoice", "invalid"},
+			wantExit:   exitError,
+			wantStderr: `unknown command "invalid"`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Capture stdout and stderr
-			oldStdout := os.Stdout
+			// Save original os.Args and restore after test
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+
+			// Capture stderr
 			oldStderr := os.Stderr
-			rOut, wOut, _ := os.Pipe()
-			rErr, wErr, _ := os.Pipe()
-			os.Stdout = wOut
-			os.Stderr = wErr
+			r, w, _ := os.Pipe()
+			os.Stderr = w
 
-			outputText(tt.result)
+			// Set os.Args for the test
+			os.Args = tt.args
 
-			wOut.Close()
-			wErr.Close()
-			os.Stdout = oldStdout
+			exitCode := run()
+
+			w.Close()
 			os.Stderr = oldStderr
 
-			var bufOut, bufErr strings.Builder
-			io.Copy(&bufOut, rOut)
-			io.Copy(&bufErr, rErr)
+			var buf strings.Builder
+			io.Copy(&buf, r)
+			stderrOutput := buf.String()
 
-			output := bufOut.String()
-			errOutput := bufErr.String()
+			if exitCode != tt.wantExit {
+				t.Errorf("run() exit code = %v, want %v", exitCode, tt.wantExit)
+			}
 
-			if tt.wantStderr {
-				if !strings.Contains(errOutput, tt.wantOutput) {
-					t.Errorf("outputText() stderr = %q, want to contain %q", errOutput, tt.wantOutput)
-				}
-			} else {
-				if !strings.Contains(output, tt.wantOutput) {
-					t.Errorf("outputText() stdout = %q, want to contain %q", output, tt.wantOutput)
-				}
+			if tt.wantStderr != "" && !strings.Contains(stderrOutput, tt.wantStderr) {
+				t.Errorf("run() stderr should contain %q, got: %v", tt.wantStderr, stderrOutput)
 			}
 		})
-	}
-}
-
-func TestIntegration_ValidFile(t *testing.T) {
-	// Test with the actual test case file if it exists
-	testFile := filepath.Join("..", "..", "testcases", "zugferd_2p0_EN16931_1_Teilrechnung.xml")
-	if _, err := os.Stat(testFile); os.IsNotExist(err) {
-		t.Skip("Test file not found, skipping integration test")
-	}
-
-	result := validateInvoice(testFile)
-
-	// Should not have a fatal error
-	if result.Error != "" {
-		t.Errorf("Integration test failed with error: %v", result.Error)
-	}
-
-	// Should have invoice metadata
-	if result.Invoice == nil {
-		t.Error("Integration test: invoice metadata is nil")
-	} else {
-		if result.Invoice.Number == "" {
-			t.Error("Integration test: invoice number is empty")
-		}
-		if result.Invoice.Total == "" {
-			t.Error("Integration test: invoice total is empty")
-		}
-	}
-
-	// Log the result for manual inspection
-	t.Logf("Invoice %s validation result: valid=%v, violations=%d",
-		result.Invoice.Number, result.Valid, len(result.Violations))
-	if len(result.Violations) > 0 {
-		t.Logf("Violations found:")
-		for _, v := range result.Violations {
-			t.Logf("  - %s", v)
-		}
 	}
 }

--- a/cmd/einvoice/main_test.go
+++ b/cmd/einvoice/main_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateInvoice(t *testing.T) {
+	tests := []struct {
+		name          string
+		filename      string
+		wantValid     bool
+		wantError     bool
+		wantViolation bool
+	}{
+		{
+			name:      "valid invoice from testcases",
+			filename:  "../../testcases/zugferd_2p0_EN16931_1_Teilrechnung.xml",
+			wantValid: false, // We don't know if this is valid without checking
+			wantError: false,
+		},
+		{
+			name:      "non-existent file",
+			filename:  "non_existent_file.xml",
+			wantValid: false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateInvoice(tt.filename)
+
+			if tt.wantError {
+				if result.Error == "" {
+					t.Errorf("validateInvoice() expected error, got none")
+				}
+				return
+			}
+
+			if result.Error != "" {
+				t.Errorf("validateInvoice() unexpected error: %v", result.Error)
+				return
+			}
+
+			// For valid test case file, just verify we got some result
+			if result.Invoice == nil {
+				t.Errorf("validateInvoice() invoice metadata is nil")
+			}
+		})
+	}
+}
+
+func TestValidateInvoice_MalformedXML(t *testing.T) {
+	// Create a temporary malformed XML file
+	tmpfile, err := os.CreateTemp("", "malformed-*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte("<invalid>xml</wrong>")); err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	result := validateInvoice(tmpfile.Name())
+
+	if result.Error == "" {
+		t.Error("validateInvoice() expected error for malformed XML, got none")
+	}
+
+	if !strings.Contains(result.Error, "parse") {
+		t.Errorf("validateInvoice() error should mention parsing, got: %v", result.Error)
+	}
+}
+
+func TestOutputJSON(t *testing.T) {
+	result := Result{
+		File:  "test.xml",
+		Valid: false,
+		Invoice: &InvoiceRef{
+			Number: "INV-001",
+			Date:   "2024-01-15",
+			Total:  "1000.00",
+		},
+		Violations: []Violation{
+			{Rule: "BR-1", Text: "violation 1"},
+			{Rule: "BR-2", Text: "violation 2"},
+		},
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	outputJSON(result)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Verify it's valid JSON
+	var decoded Result
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Errorf("outputJSON() produced invalid JSON: %v", err)
+	}
+
+	// Verify content
+	if decoded.File != "test.xml" {
+		t.Errorf("outputJSON() file = %v, want %v", decoded.File, "test.xml")
+	}
+	if decoded.Valid != false {
+		t.Errorf("outputJSON() valid = %v, want %v", decoded.Valid, false)
+	}
+	if len(decoded.Violations) != 2 {
+		t.Errorf("outputJSON() violations count = %v, want %v", len(decoded.Violations), 2)
+	}
+}
+
+func TestOutputText(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     Result
+		wantStderr bool
+		wantOutput string
+	}{
+		{
+			name: "valid invoice",
+			result: Result{
+				File:  "test.xml",
+				Valid: true,
+				Invoice: &InvoiceRef{
+					Number: "INV-001",
+				},
+			},
+			wantStderr: false,
+			wantOutput: "✓ Invoice INV-001 is valid",
+		},
+		{
+			name: "invalid invoice with violations",
+			result: Result{
+				File:  "test.xml",
+				Valid: false,
+				Invoice: &InvoiceRef{
+					Number: "INV-002",
+				},
+				Violations: []Violation{
+					{Rule: "BR-1", Text: "violation"},
+				},
+			},
+			wantStderr: false,
+			wantOutput: "✗ Invoice INV-002 has 1 violation(s):",
+		},
+		{
+			name: "error case",
+			result: Result{
+				File:  "test.xml",
+				Error: "file not found",
+			},
+			wantStderr: true,
+			wantOutput: "Error: file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout and stderr
+			oldStdout := os.Stdout
+			oldStderr := os.Stderr
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			outputText(tt.result)
+
+			wOut.Close()
+			wErr.Close()
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+
+			var bufOut, bufErr strings.Builder
+			io.Copy(&bufOut, rOut)
+			io.Copy(&bufErr, rErr)
+
+			output := bufOut.String()
+			errOutput := bufErr.String()
+
+			if tt.wantStderr {
+				if !strings.Contains(errOutput, tt.wantOutput) {
+					t.Errorf("outputText() stderr = %q, want to contain %q", errOutput, tt.wantOutput)
+				}
+			} else {
+				if !strings.Contains(output, tt.wantOutput) {
+					t.Errorf("outputText() stdout = %q, want to contain %q", output, tt.wantOutput)
+				}
+			}
+		})
+	}
+}
+
+func TestIntegration_ValidFile(t *testing.T) {
+	// Test with the actual test case file if it exists
+	testFile := filepath.Join("..", "..", "testcases", "zugferd_2p0_EN16931_1_Teilrechnung.xml")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("Test file not found, skipping integration test")
+	}
+
+	result := validateInvoice(testFile)
+
+	// Should not have a fatal error
+	if result.Error != "" {
+		t.Errorf("Integration test failed with error: %v", result.Error)
+	}
+
+	// Should have invoice metadata
+	if result.Invoice == nil {
+		t.Error("Integration test: invoice metadata is nil")
+	} else {
+		if result.Invoice.Number == "" {
+			t.Error("Integration test: invoice number is empty")
+		}
+		if result.Invoice.Total == "" {
+			t.Error("Integration test: invoice total is empty")
+		}
+	}
+
+	// Log the result for manual inspection
+	t.Logf("Invoice %s validation result: valid=%v, violations=%d",
+		result.Invoice.Number, result.Valid, len(result.Violations))
+	if len(result.Violations) > 0 {
+		t.Logf("Violations found:")
+		for _, v := range result.Violations {
+			t.Logf("  - %s", v)
+		}
+	}
+}

--- a/cmd/einvoice/main_test.go
+++ b/cmd/einvoice/main_test.go
@@ -46,7 +46,7 @@ func TestRun(t *testing.T) {
 
 			exitCode := run()
 
-			w.Close()
+			_ = w.Close()
 			os.Stderr = oldStderr
 
 			if exitCode != tt.wantExit {
@@ -64,11 +64,11 @@ func TestUsage(t *testing.T) {
 
 	usage()
 
-	w.Close()
+	_ = w.Close()
 	os.Stderr = oldStderr
 
 	var buf strings.Builder
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	output := buf.String()
 
 	// Verify usage output contains expected elements
@@ -123,11 +123,11 @@ func TestSubcommandDispatch(t *testing.T) {
 
 			exitCode := run()
 
-			w.Close()
+			_ = w.Close()
 			os.Stderr = oldStderr
 
 			var buf strings.Builder
-			io.Copy(&buf, r)
+			_, _ = io.Copy(&buf, r)
 			stderrOutput := buf.String()
 
 			if exitCode != tt.wantExit {

--- a/cmd/einvoice/validate.go
+++ b/cmd/einvoice/validate.go
@@ -37,7 +37,6 @@ func runValidate(args []string) int {
 	validateFlags := flag.NewFlagSet("validate", flag.ExitOnError)
 	var format string
 	validateFlags.StringVar(&format, "format", "text", "Output format: text, json")
-	validateFlags.StringVar(&format, "f", "text", "Output format: text, json (shorthand)")
 	validateFlags.Usage = validateUsage
 	validateFlags.Parse(args)
 
@@ -149,8 +148,8 @@ func validateUsage() {
 Validates an electronic invoice against EN 16931 business rules.
 
 Options:
-  -f, --format string   Output format: text, json (default "text")
-  -h, --help            Show this help message
+  --format string   Output format: text, json (default "text")
+  --help            Show this help message
 
 Exit codes:
   0  Invoice is valid

--- a/cmd/einvoice/validate.go
+++ b/cmd/einvoice/validate.go
@@ -38,7 +38,7 @@ func runValidate(args []string) int {
 	var format string
 	validateFlags.StringVar(&format, "format", "text", "Output format: text, json")
 	validateFlags.Usage = validateUsage
-	validateFlags.Parse(args)
+	_ = validateFlags.Parse(args)
 
 	// Require exactly one file argument
 	if validateFlags.NArg() != 1 {

--- a/cmd/einvoice/validate.go
+++ b/cmd/einvoice/validate.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/speedata/einvoice"
+)
+
+// Result represents the validation result for JSON output
+type Result struct {
+	File       string       `json:"file"`
+	Valid      bool         `json:"valid"`
+	Invoice    *InvoiceRef  `json:"invoice,omitempty"`
+	Violations []Violation  `json:"violations,omitempty"`
+	Error      string       `json:"error,omitempty"`
+}
+
+// Violation represents a business rule violation
+type Violation struct {
+	Rule   string   `json:"rule"`
+	Fields []string `json:"fields,omitempty"`
+	Text   string   `json:"text"`
+}
+
+// InvoiceRef contains basic invoice metadata
+type InvoiceRef struct {
+	Number string `json:"number,omitempty"`
+	Date   string `json:"date,omitempty"`
+	Total  string `json:"total,omitempty"`
+}
+
+func runValidate(args []string) int {
+	// Parse flags for the validate subcommand
+	validateFlags := flag.NewFlagSet("validate", flag.ExitOnError)
+	var format string
+	validateFlags.StringVar(&format, "format", "text", "Output format: text, json")
+	validateFlags.StringVar(&format, "f", "text", "Output format: text, json (shorthand)")
+	validateFlags.Usage = validateUsage
+	validateFlags.Parse(args)
+
+	// Require exactly one file argument
+	if validateFlags.NArg() != 1 {
+		validateUsage()
+		return exitError
+	}
+
+	filename := validateFlags.Arg(0)
+
+	// Validate the invoice
+	result := validateInvoice(filename)
+
+	// Output results
+	switch format {
+	case "json":
+		outputJSON(result)
+	case "text":
+		outputText(result)
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown format %q (use 'text' or 'json')\n", format)
+		return exitError
+	}
+
+	// Return appropriate exit code
+	if result.Error != "" {
+		return exitError
+	}
+	if !result.Valid {
+		return exitViolations
+	}
+	return exitOK
+}
+
+func validateInvoice(filename string) Result {
+	result := Result{
+		File: filename,
+	}
+
+	// Parse the invoice XML
+	invoice, err := einvoice.ParseXMLFile(filename)
+	if err != nil {
+		result.Error = fmt.Sprintf("Failed to parse invoice: %v", err)
+		return result
+	}
+
+	// Extract basic invoice metadata
+	result.Invoice = &InvoiceRef{
+		Number: invoice.InvoiceNumber,
+		Date:   invoice.InvoiceDate.Format("2006-01-02"),
+		Total:  invoice.GrandTotal.String(),
+	}
+
+	// Validate the invoice
+	validationErr := invoice.Validate()
+	if validationErr == nil {
+		result.Valid = true
+		return result
+	}
+
+	// Extract violations
+	if ve, ok := validationErr.(*einvoice.ValidationError); ok {
+		result.Valid = false
+		semanticErrors := ve.Violations()
+		result.Violations = make([]Violation, len(semanticErrors))
+		for i, se := range semanticErrors {
+			result.Violations[i] = Violation{
+				Rule:   se.Rule,
+				Fields: se.InvFields,
+				Text:   se.Text,
+			}
+		}
+	} else {
+		result.Error = fmt.Sprintf("Validation failed: %v", validationErr)
+	}
+
+	return result
+}
+
+func outputText(result Result) {
+	if result.Error != "" {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", result.Error)
+		return
+	}
+
+	if result.Valid {
+		fmt.Printf("✓ Invoice %s is valid\n", result.Invoice.Number)
+		return
+	}
+
+	fmt.Printf("✗ Invoice %s has %d violation(s):\n", result.Invoice.Number, len(result.Violations))
+	for _, violation := range result.Violations {
+		fmt.Printf("  - %s: %s\n", violation.Rule, violation.Text)
+	}
+}
+
+func outputJSON(result Result) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+	}
+}
+
+func validateUsage() {
+	fmt.Fprintf(os.Stderr, `Usage: einvoice validate [options] <file.xml>
+
+Validates an electronic invoice against EN 16931 business rules.
+
+Options:
+  -f, --format string   Output format: text, json (default "text")
+  -h, --help            Show this help message
+
+Exit codes:
+  0  Invoice is valid
+  1  Invoice has validation violations
+  2  Error occurred (file not found, parse error, etc.)
+
+Examples:
+  einvoice validate invoice.xml
+  einvoice validate --format json invoice.xml
+`)
+}

--- a/cmd/einvoice/validate_test.go
+++ b/cmd/einvoice/validate_test.go
@@ -61,12 +61,12 @@ func TestValidateInvoice_MalformedXML(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tmpfile.Name())
+	defer func() { _ = os.Remove(tmpfile.Name()) }()
 
 	if _, err := tmpfile.Write([]byte("<invalid>xml</wrong>")); err != nil {
 		t.Fatal(err)
 	}
-	tmpfile.Close()
+	_ = tmpfile.Close()
 
 	result := validateInvoice(tmpfile.Name())
 
@@ -101,11 +101,11 @@ func TestOutputJSON(t *testing.T) {
 
 	outputJSON(result)
 
-	w.Close()
+	_ = w.Close()
 	os.Stdout = oldStdout
 
 	var buf strings.Builder
-	io.Copy(&buf, r)
+	_, _ = io.Copy(&buf, r)
 	output := buf.String()
 
 	// Verify it's valid JSON
@@ -183,14 +183,14 @@ func TestOutputText(t *testing.T) {
 
 			outputText(tt.result)
 
-			wOut.Close()
-			wErr.Close()
+			_ = wOut.Close()
+			_ = wErr.Close()
 			os.Stdout = oldStdout
 			os.Stderr = oldStderr
 
 			var bufOut, bufErr strings.Builder
-			io.Copy(&bufOut, rOut)
-			io.Copy(&bufErr, rErr)
+			_, _ = io.Copy(&bufOut, rOut)
+			_, _ = io.Copy(&bufErr, rErr)
 
 			output := bufOut.String()
 			errOutput := bufErr.String()
@@ -240,7 +240,7 @@ func TestRunValidate(t *testing.T) {
 
 			exitCode := runValidate(tt.args)
 
-			w.Close()
+			_ = w.Close()
 			os.Stderr = oldStderr
 
 			if exitCode != tt.wantExit {
@@ -323,8 +323,8 @@ func TestIntegration_ValidateCommand(t *testing.T) {
 
 			exitCode := runValidate(tt.args)
 
-			wOut.Close()
-			wErr.Close()
+			_ = wOut.Close()
+			_ = wErr.Close()
 			os.Stdout = oldStdout
 			os.Stderr = oldStderr
 

--- a/cmd/einvoice/validate_test.go
+++ b/cmd/einvoice/validate_test.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateInvoice(t *testing.T) {
+	tests := []struct {
+		name          string
+		filename      string
+		wantValid     bool
+		wantError     bool
+		wantViolation bool
+	}{
+		{
+			name:      "valid invoice from testcases",
+			filename:  "../../testcases/zugferd_2p0_EN16931_1_Teilrechnung.xml",
+			wantValid: false, // We don't know if this is valid without checking
+			wantError: false,
+		},
+		{
+			name:      "non-existent file",
+			filename:  "non_existent_file.xml",
+			wantValid: false,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateInvoice(tt.filename)
+
+			if tt.wantError {
+				if result.Error == "" {
+					t.Errorf("validateInvoice() expected error, got none")
+				}
+				return
+			}
+
+			if result.Error != "" {
+				t.Errorf("validateInvoice() unexpected error: %v", result.Error)
+				return
+			}
+
+			// For valid test case file, just verify we got some result
+			if result.Invoice == nil {
+				t.Errorf("validateInvoice() invoice metadata is nil")
+			}
+		})
+	}
+}
+
+func TestValidateInvoice_MalformedXML(t *testing.T) {
+	// Create a temporary malformed XML file
+	tmpfile, err := os.CreateTemp("", "malformed-*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write([]byte("<invalid>xml</wrong>")); err != nil {
+		t.Fatal(err)
+	}
+	tmpfile.Close()
+
+	result := validateInvoice(tmpfile.Name())
+
+	if result.Error == "" {
+		t.Error("validateInvoice() expected error for malformed XML, got none")
+	}
+
+	if !strings.Contains(result.Error, "parse") {
+		t.Errorf("validateInvoice() error should mention parsing, got: %v", result.Error)
+	}
+}
+
+func TestOutputJSON(t *testing.T) {
+	result := Result{
+		File:  "test.xml",
+		Valid: false,
+		Invoice: &InvoiceRef{
+			Number: "INV-001",
+			Date:   "2024-01-15",
+			Total:  "1000.00",
+		},
+		Violations: []Violation{
+			{Rule: "BR-1", Text: "violation 1"},
+			{Rule: "BR-2", Text: "violation 2"},
+		},
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	outputJSON(result)
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	// Verify it's valid JSON
+	var decoded Result
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Errorf("outputJSON() produced invalid JSON: %v", err)
+	}
+
+	// Verify content
+	if decoded.File != "test.xml" {
+		t.Errorf("outputJSON() file = %v, want %v", decoded.File, "test.xml")
+	}
+	if decoded.Valid != false {
+		t.Errorf("outputJSON() valid = %v, want %v", decoded.Valid, false)
+	}
+	if len(decoded.Violations) != 2 {
+		t.Errorf("outputJSON() violations count = %v, want %v", len(decoded.Violations), 2)
+	}
+}
+
+func TestOutputText(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     Result
+		wantStderr bool
+		wantOutput string
+	}{
+		{
+			name: "valid invoice",
+			result: Result{
+				File:  "test.xml",
+				Valid: true,
+				Invoice: &InvoiceRef{
+					Number: "INV-001",
+				},
+			},
+			wantStderr: false,
+			wantOutput: "✓ Invoice INV-001 is valid",
+		},
+		{
+			name: "invalid invoice with violations",
+			result: Result{
+				File:  "test.xml",
+				Valid: false,
+				Invoice: &InvoiceRef{
+					Number: "INV-002",
+				},
+				Violations: []Violation{
+					{Rule: "BR-1", Text: "violation"},
+				},
+			},
+			wantStderr: false,
+			wantOutput: "✗ Invoice INV-002 has 1 violation(s):",
+		},
+		{
+			name: "error case",
+			result: Result{
+				File:  "test.xml",
+				Error: "file not found",
+			},
+			wantStderr: true,
+			wantOutput: "Error: file not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout and stderr
+			oldStdout := os.Stdout
+			oldStderr := os.Stderr
+			rOut, wOut, _ := os.Pipe()
+			rErr, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			outputText(tt.result)
+
+			wOut.Close()
+			wErr.Close()
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+
+			var bufOut, bufErr strings.Builder
+			io.Copy(&bufOut, rOut)
+			io.Copy(&bufErr, rErr)
+
+			output := bufOut.String()
+			errOutput := bufErr.String()
+
+			if tt.wantStderr {
+				if !strings.Contains(errOutput, tt.wantOutput) {
+					t.Errorf("outputText() stderr = %q, want to contain %q", errOutput, tt.wantOutput)
+				}
+			} else {
+				if !strings.Contains(output, tt.wantOutput) {
+					t.Errorf("outputText() stdout = %q, want to contain %q", output, tt.wantOutput)
+				}
+			}
+		})
+	}
+}
+
+func TestRunValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantExit int
+	}{
+		{
+			name:     "no arguments",
+			args:     []string{},
+			wantExit: exitError,
+		},
+		{
+			name:     "non-existent file",
+			args:     []string{"non-existent.xml"},
+			wantExit: exitError,
+		},
+		{
+			name:     "invalid format option",
+			args:     []string{"--format", "xml", "test.xml"},
+			wantExit: exitError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stderr to suppress output during tests
+			oldStderr := os.Stderr
+			_, w, _ := os.Pipe()
+			os.Stderr = w
+
+			exitCode := runValidate(tt.args)
+
+			w.Close()
+			os.Stderr = oldStderr
+
+			if exitCode != tt.wantExit {
+				t.Errorf("runValidate() exit code = %v, want %v", exitCode, tt.wantExit)
+			}
+		})
+	}
+}
+
+func TestIntegration_ValidFile(t *testing.T) {
+	// Test with the actual test case file if it exists
+	testFile := filepath.Join("..", "..", "testcases", "zugferd_2p0_EN16931_1_Teilrechnung.xml")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("Test file not found, skipping integration test")
+	}
+
+	result := validateInvoice(testFile)
+
+	// Should not have a fatal error
+	if result.Error != "" {
+		t.Errorf("Integration test failed with error: %v", result.Error)
+	}
+
+	// Should have invoice metadata
+	if result.Invoice == nil {
+		t.Error("Integration test: invoice metadata is nil")
+	} else {
+		if result.Invoice.Number == "" {
+			t.Error("Integration test: invoice number is empty")
+		}
+		if result.Invoice.Total == "" {
+			t.Error("Integration test: invoice total is empty")
+		}
+	}
+
+	// Log the result for manual inspection
+	t.Logf("Invoice %s validation result: valid=%v, violations=%d",
+		result.Invoice.Number, result.Valid, len(result.Violations))
+	if len(result.Violations) > 0 {
+		t.Logf("Violations found:")
+		for _, v := range result.Violations {
+			t.Logf("  - %+v", v)
+		}
+	}
+}
+
+func TestIntegration_ValidateCommand(t *testing.T) {
+	// Test with the actual test case file if it exists
+	testFile := filepath.Join("..", "..", "testcases", "zugferd_2p0_EN16931_1_Teilrechnung.xml")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("Test file not found, skipping integration test")
+	}
+
+	tests := []struct {
+		name     string
+		args     []string
+		wantExit int
+	}{
+		{
+			name:     "validate with text output",
+			args:     []string{testFile},
+			wantExit: exitViolations, // We know this file has violations
+		},
+		{
+			name:     "validate with json output",
+			args:     []string{"--format", "json", testFile},
+			wantExit: exitViolations,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture stdout and stderr to suppress output during tests
+			oldStdout := os.Stdout
+			oldStderr := os.Stderr
+			_, wOut, _ := os.Pipe()
+			_, wErr, _ := os.Pipe()
+			os.Stdout = wOut
+			os.Stderr = wErr
+
+			exitCode := runValidate(tt.args)
+
+			wOut.Close()
+			wErr.Close()
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+
+			if exitCode != tt.wantExit {
+				t.Errorf("runValidate() exit code = %v, want %v", exitCode, tt.wantExit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR implements the MVP validate command as proposed in #13.

## Overview

Adds a CLI tool that validates electronic invoices against EN 16931 business rules.

## Features

### Command
```bash
einvoice validate <file.xml>
```

### Output Formats
- **Text (default)**: Human-readable output with ✓/✗ indicators
- **JSON** (`--format json`): Structured output for automation/CI/CD

### Exit Codes
- `0`: Invoice is valid
- `1`: Invoice has validation violations
- `2`: Error occurred (file not found, parse error, etc.)

### Example Usage
```bash
# Validate with text output
einvoice validate invoice.xml

# Validate with JSON output
einvoice validate --format json invoice.xml

# Use in shell scripts
if einvoice validate invoice.xml; then
    echo "Valid!"
fi
```

## Implementation

### File Structure
- `cmd/einvoice/main.go`: Entry point and subcommand dispatcher
- `cmd/einvoice/validate.go`: Validate command implementation  
- `cmd/einvoice/main_test.go`: Comprehensive test suite

### Design Decisions
1. **Subcommand structure**: Ready for future commands (info, fix) without refactoring
2. **Minimal dependencies**: Uses stdlib flag package for argument parsing
3. **Library integration**: Leverages existing `Invoice.Validate()` API - no business logic duplication
4. **Two-level help**: Main usage shows available commands, validate usage shows command-specific options

## Testing
- ✅ All unit tests pass
- ✅ Integration test with real invoice file
- ✅ Exit codes verified for all scenarios
- ✅ Both text and JSON output formats tested

## Documentation
Updated `Readme.md` with CLI installation instructions, usage examples, and exit codes.

## Alignment with RFC #13
This implements **Phase 1** as discussed with @pgundlach:
- ✅ Focus on `validate` command first
- ✅ Keep it simple and avoid bloat
- ✅ Text and JSON output formats
- ⏭️ Defer advanced features (JUnit, batch processing, colors) to future PRs based on feedback

## Future Enhancements (Phase 2+)
- Optional colored output for terminals
- `info` command for invoice summary
- Additional output formats (JUnit XML) if requested
