### PR TITLE
Add GitHub releases badge to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,6 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/speedata/einvoice.svg)](https://pkg.go.dev/github.com/speedata/einvoice)
 [![Go Report Card](https://goreportcard.com/badge/github.com/speedata/einvoice)](https://goreportcard.com/report/github.com/speedata/einvoice)
+[![Releases](https://img.shields.io/github/v/release/speedata/einvoice?include_prereleases)](https://github.com/speedata/einvoice/releases/latest)
 
 # einvoice - a Go library to read, write and verify electronic invoices
 


### PR DESCRIPTION
Adds a GitHub releases badge to display the latest version alongside the existing Go Reference and Go Report Card badges.

The badge provides quick visibility into the current release status of the library.