### PR TITLE
Fix VAT calculation and validation issues

### DIFF
--- a/check.go
+++ b/check.go
@@ -156,22 +156,14 @@ func (inv *Invoice) checkBRO() {
 	// BR-CO-19 Liefer- oder Rechnungszeitraum
 	// Wenn die Gruppe "INVOICING PERIOD" (BG-14) verwendet wird, müssen entweder das Element "Invoicing period start date" (BT-73) oder das
 	// Element "Invoicing period end date" (BT-74) oder beide gefüllt sein.
-	if !inv.BillingSpecifiedPeriodStart.IsZero() || !inv.BillingSpecifiedPeriodEnd.IsZero() {
-		if inv.BillingSpecifiedPeriodStart.IsZero() && inv.BillingSpecifiedPeriodEnd.IsZero() {
-			inv.addViolation(rules.BRCO19, "If invoicing period is used, either start date or end date must be filled")
-		}
-	}
+	// Note: If at least one date is set (!IsZero()), then BR-CO-19 is automatically satisfied.
+	// The rule only applies when BG-14 is present in XML, which our writer ensures by only writing when at least one date exists.
 
 	// BR-CO-20 Rechnungszeitraum auf Positionsebene
 	// Wenn die Gruppe "INVOICE LINE PERIOD" (BG-26) verwendet wird, müssen entweder das Element "Invoice line period start date" (BT-134) oder
 	// das Element "Invoice line period end date" (BT-135) oder beide gefüllt sein.
-	for _, line := range inv.InvoiceLines {
-		if !line.BillingSpecifiedPeriodStart.IsZero() || !line.BillingSpecifiedPeriodEnd.IsZero() {
-			if line.BillingSpecifiedPeriodStart.IsZero() && line.BillingSpecifiedPeriodEnd.IsZero() {
-				inv.addViolation(rules.BRCO20, fmt.Sprintf("Invoice line %s: if line period is used, either start date or end date must be filled", line.LineID))
-			}
-		}
-	}
+	// Note: If at least one date is set (!IsZero()), then BR-CO-20 is automatically satisfied.
+	// The rule only applies when BG-26 is present in XML, which our writer ensures by only writing when at least one date exists.
 
 	// BR-CO-25 Rechnung
 	// Im Falle eines positiven Zahlbetrags "Amount due for payment" (BT-115) muss entweder das Element Fälligkeitsdatum "Payment due date" (BT-9)

--- a/check_vat_igic.go
+++ b/check_vat_igic.go
@@ -78,7 +78,7 @@ func (inv *Invoice) checkVATIGIC() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal)
+			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAF5, fmt.Sprintf("IGIC taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -118,7 +118,7 @@ func (inv *Invoice) checkVATIGIC() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "L" {
 			key := tt.Percent.String()
-			expectedBasis := igicRateMap[key]
+			expectedBasis := igicRateMap[key].Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAF7, fmt.Sprintf("IGIC taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/check_vat_intracommunity.go
+++ b/check_vat_intracommunity.go
@@ -121,7 +121,7 @@ func (inv *Invoice) checkVATIntracommunity() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal)
+			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRIC6, fmt.Sprintf("Intra-community supply taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -158,7 +158,7 @@ func (inv *Invoice) checkVATIntracommunity() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "K" {
 			key := tt.Percent.String()
-			expectedBasis := taxRateMap[key]
+			expectedBasis := taxRateMap[key].Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRIC8, fmt.Sprintf("Intra-community supply taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/check_vat_ipsi.go
+++ b/check_vat_ipsi.go
@@ -79,7 +79,7 @@ func (inv *Invoice) checkVATIPSI() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal)
+			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAG5, fmt.Sprintf("IPSI taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -119,7 +119,7 @@ func (inv *Invoice) checkVATIPSI() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "M" {
 			key := tt.Percent.String()
-			expectedBasis := ipsiRateMap[key]
+			expectedBasis := ipsiRateMap[key].Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAG7, fmt.Sprintf("IPSI taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/check_vat_notsubject.go
+++ b/check_vat_notsubject.go
@@ -165,7 +165,7 @@ func (inv *Invoice) checkVATNotSubject() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal)
+			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRO9, fmt.Sprintf("Not subject to VAT taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -194,7 +194,7 @@ func (inv *Invoice) checkVATNotSubject() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "O" {
 			key := tt.Percent.String()
-			expectedBasis := notSubjectRateMap[key]
+			expectedBasis := notSubjectRateMap[key].Round(2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRO10, fmt.Sprintf("Not subject to VAT taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}


### PR DESCRIPTION
## Summary

This PR fixes two critical issues identified during a comprehensive codebase review:
1. Missing rounding in VAT category basis validations (4 files)
2. Redundant BR-CO-19/BR-CO-20 validation logic

Both issues have been fixed with comprehensive test coverage and no regressions.

---

## Missing Rounding in VAT Category Basis Validations

### Problem

Four VAT category validation files were missing `.Round(2)` calls when calculating expected basis amounts for comparison with `TradeTax.BasisAmount`. This caused **false violations** when invoice line totals had more than 2 decimal places.

**Root cause**: The `UpdateApplicableTradeTax()` function rounds `BasisAmount` to 2 decimals (line 79 in calculate.go), but the validation logic in four category files calculated unrounded expected values for comparison, leading to mismatches like:
- Stored value: `100.00` (rounded)
- Calculated value: `100.001` (unrounded)
- Result: False violation triggered

### Affected Business Rules
- BR-IC-06, BR-IC-08 (Intracommunity supply - category K)
- BR-O-09, BR-O-10 (Not subject to VAT - category O)
- BR-AF-05, BR-AF-07 (IGIC Canary Islands - category L)
- BR-AG-05, BR-AG-07 (IPSI Ceuta/Melilla - category M)

### Files Fixed

Added `.Round(2)` to expected basis calculations:
- `check_vat_intracommunity.go`: Lines 124, 161
- `check_vat_notsubject.go`: Lines 168, 197
- `check_vat_igic.go`: Lines 81, 121
- `check_vat_ipsi.go`: Lines 82, 122

This aligns with existing implementations in:
- ✓ `check_vat_exempt.go` (already had rounding)
- ✓ `check_vat_reverse.go` (already had rounding)
- ✓ `check_vat_zero.go` (already had rounding)
- ✓ `check_vat_export.go` (already had rounding)
- ✓ `check_vat_standard.go` (already had rounding)

### Example Fix

**Before (check_vat_intracommunity.go:124)**:
```go
expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal)
```

**After**:
```go
expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
```

---

## Redundant BR-CO-19/BR-CO-20 Validation Logic

### Problem

The validation logic for BR-CO-19 (invoice period) and BR-CO-20 (invoice line period) contained logically impossible nested conditions:

```go
if !start.IsZero() || !end.IsZero() {  // "If at least one date is set..."
    if start.IsZero() && end.IsZero() {  // "...check if both are zero"
        violation
    }
}
```

The inner condition **can never be true** if the outer condition is true.

### Root Cause

The rules state: "If INVOICING PERIOD (BG-14) is used, at least one date must be filled."

However:
1. The Go struct has no way to distinguish "BG-14 not present in XML" from "BG-14 present with zero dates"
2. The writer only outputs BG-14 when at least one date exists (correct behavior)
4. The outer `if` already ensures the rule is satisfied

### Solution

Removed the redundant validation logic and added clarifying comments explaining why the rules are satisfied by construction. The writer ensures compliance by only writing the groups when at least one date exists.

**File**: `check.go` (lines 156-166)

---

## Testing

Created comprehensive test suite in `critical_issues_test.go`:

### C1 Tests (7 tests)
- ✓ `TestC1_MissingRoundingInVATExempt` - Category E (already had rounding, baseline)
- ✓ `TestC1_MissingRoundingInVATReverseCharge` - Category AE (already had rounding, baseline)
- ✓ `TestC1_MissingRoundingInVATZeroRated` - Category Z (already had rounding, baseline)
- ✓ `TestC1_MissingRoundingInVATIntracommunity` - **Category K (fixed)**
- ✓ `TestC1_MissingRoundingInVATNotSubject` - **Category O (fixed)**
- ✓ `TestC1_MissingRoundingInVATIGIC` - **Category L (fixed)**
- ✓ `TestC1_MissingRoundingInVATIPSI` - **Category M (fixed)**
- ✓ `TestC1_AllVATCategoriesWithDocumentLevelAllowances` - Integration test

### C2 Tests (2 tests)
- ✓ `TestC2_BRCO19_LogicError` - Invoice period validation (3 subtests)
- ✓ `TestC2_BRCO20_LogicError` - Invoice line period validation (2 subtests)

### Test Strategy

1. **Before fix**: Tests used values that sum to exactly 100.000 → rounded to 100.00 → no violation (bug not exposed)
2. **After investigation**: Updated test values to sum to 100.001 → rounds to 100.00 → would trigger false violation without fix
3. **After fix**: Tests verify that specific violations (BR-IC-06, BR-O-09, etc.) are **not** triggered

### Test Results
```
$ go test
PASS
ok      github.com/speedata/einvoice    0.015s
```

All 223 tests pass with no regressions.

---

## Changes Summary

- **6 files changed**: 807 insertions(+), 20 deletions(-)
- **New file**: `critical_issues_test.go` (642 lines)
- **Modified files**:
  - `check.go`: Removed redundant validation logic
  - `check_vat_intracommunity.go`: Added rounding (2 locations)
  - `check_vat_notsubject.go`: Added rounding (2 locations)
  - `check_vat_igic.go`: Added rounding (2 locations)
  - `check_vat_ipsi.go`: Added rounding (2 locations)

---

## Compliance

These fixes ensure strict compliance with:
- **EN 16931** standard for electronic invoicing
- **BR-DEC-19**: VAT category taxable amount must have max 2 decimal places
- **BR-IC-06, BR-IC-08**: Intracommunity supply validation rules
- **BR-O-09, BR-O-10**: Not subject to VAT validation rules
- **BR-AF-05, BR-AF-07**: IGIC validation rules
- **BR-AG-05, BR-AG-07**: IPSI validation rules

---

## Checklist

- [x] All tests pass
- [x] No regressions in existing functionality
- [x] Comprehensive test coverage for both fixes
- [x] Fixes align with existing patterns in codebase
- [x] Comments added explaining C2 logic removal
- [x] Commit message follows project conventions