### PR TITLE
Remove invalid BT-131 calculation check

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,22 +1,11 @@
 package einvoice
 
 import (
-	"github.com/speedata/einvoice/rules"
 	"fmt"
 
 	"github.com/shopspring/decimal"
+	"github.com/speedata/einvoice/rules"
 )
-
-func (inv *Invoice) checkOther() {
-	// Check that line total = billed quantity * net price
-	for _, line := range inv.InvoiceLines {
-		calcTotal := line.BilledQuantity.Mul(line.NetPrice)
-		lineTotal := line.Total
-		if !lineTotal.Equal(calcTotal) {
-			inv.addViolation(rules.Check, fmt.Sprintf("Line total %s does not match quantity %s * net price %s", lineTotal.String(), line.BilledQuantity.String(), calcTotal.String()))
-		}
-	}
-}
 
 func (inv *Invoice) checkBRO() {
 	var sum decimal.Decimal

--- a/rules/custom.go
+++ b/rules/custom.go
@@ -4,13 +4,6 @@ package rules
 // but used in the validation logic. These are manually maintained.
 
 var (
-	// Check validates that invoice line net amount equals quantity × net price
-	Check = Rule{
-		Code:        "Check",
-		Fields:      []string{"BT-131", "BT-129", "BT-146", "BT-149"},
-		Description: `Invoice line net amount (BT-131) = invoiced quantity (BT-129) × item net price (BT-146) / item price base quantity (BT-149)`,
-	}
-
 	// BR34-40: These rules are not in the EN 16931 schematron but validate
 	// that allowance and charge amounts are non-negative.
 	BR34 = Rule{

--- a/validation.go
+++ b/validation.go
@@ -144,7 +144,6 @@ func (inv *Invoice) Validate() error {
 	inv.checkBR()
 	inv.checkBRO()
 	inv.checkBRDEC()
-	inv.checkOther()
 
 	// Return error if violations exist
 	if len(inv.violations) > 0 {
@@ -168,7 +167,6 @@ func (inv *Invoice) ValidatePEPPOL() error {
 	// Run EN 16931 validation checks
 	inv.checkBR()
 	inv.checkBRO()
-	inv.checkOther()
 
 	// Run PEPPOL validation checks
 	inv.checkPEPPOL()


### PR DESCRIPTION
## Summary

Removes the custom "Check" rule that validated BT-131 (Invoice line net amount) calculation. This rule was producing false positive violations on valid invoices.

## Issues with the Check Rule

### 1. Incomplete Formula
The rule only checked: `BT-131 = BT-129 × BT-146`

But the complete EN 16931 formula is:
```
BT-131 = (BT-129 × BT-146 / BT-149) + BT-141 - BT-136
```

Where:
- **BT-129**: Invoiced quantity
- **BT-146**: Item net price
- **BT-149**: Item price base quantity (divisor)
- **BT-141**: Sum of invoice line charges
- **BT-136**: Sum of invoice line allowances

### 2. Rounding Precision Issue
The validation used exact decimal comparison (`decimal.Equal()`) without accounting for BR-DEC-23, which requires BT-131 to be rounded to maximum 2 decimal places.

**Example false positive:**
- Calculation: 73.25 × 148.50 = 10,877.625
- Rounded (BR-DEC-23): 10,877.63 ✓ **Correct**
- Check rule: Failed because 10877.625 ≠ 10877.63

### 3. Not an Official Rule
This was a custom rule not present in the EN 16931 schematron specification. The official specification only requires:
- BR-DEC-23: BT-131 maximum 2 decimals
- BR-CO-10: Sum of line amounts equals invoice line sum total

## Changes

- **Removed** `checkOther()` function (check.go)
- **Removed** `Check` rule definition (rules/custom.go)
- **Removed** `inv.checkOther()` calls from `Validate()` and `ValidatePEPPOL()` (validation.go)

## Testing

All tests pass:
```bash
go test ./... -short
```

Validated sample invoices that previously showed false positives now validate correctly while legitimate VAT rounding violations are still detected.

## References

- EN 16931 BT-131 specification
- BR-DEC-23: Maximum 2 decimal places for invoice line net amount