### PR TITLE
Add checkBRDEC() to ValidatePEPPOL()

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -167,6 +167,7 @@ func (inv *Invoice) ValidatePEPPOL() error {
 	// Run EN 16931 validation checks
 	inv.checkBR()
 	inv.checkBRO()
+	inv.checkBRDEC()
 
 	// Run PEPPOL validation checks
 	inv.checkPEPPOL()


### PR DESCRIPTION
## Summary
- Fixes inconsistency between `Validate()` and `ValidatePEPPOL()` methods
- `ValidatePEPPOL()` was missing decimal precision validation that `Validate()` performs
- Adds `inv.checkBRDEC()` call to `ValidatePEPPOL()` to ensure PEPPOL invoices are validated for decimal precision rules

## Changes
- **validation.go**: Added `inv.checkBRDEC()` call to `ValidatePEPPOL()` method
- **check_peppol_test.go**: Added `TestValidatePEPPOL_DecimalPrecisionViolations` test to verify the fix

## Test Results
All tests pass including the new test that verifies BR-DEC violations are detected by `ValidatePEPPOL()`.

## Related Issues
Fixes issue H2 from bug analysis - ValidatePEPPOL() missing checkBRDEC() call