### PR TITLE
Fix VAT rounding to use commercial rounding (round half up)

### DIFF
--- a/check.go
+++ b/check.go
@@ -130,7 +130,7 @@ func (inv *Invoice) checkBRO() {
 	// Der Inhalt des Elementes "VAT category tax amount" (BT-117) entspricht dem Inhalt des Elementes "VAT category taxable amount" (BT-116),
 	// multipliziert mit dem Inhalt des Elementes "VAT category rate" (BT-119) geteilt durch 100, gerundet auf zwei Dezimalstellen.
 	for _, tax := range inv.TradeTaxes {
-		expected := tax.BasisAmount.Mul(tax.Percent).Div(decimal.NewFromInt(100)).Round(2)
+		expected := roundHalfUp(tax.BasisAmount.Mul(tax.Percent).Div(decimal.NewFromInt(100)), 2)
 		if !tax.CalculatedAmount.Equal(expected) {
 			inv.addViolation(rules.BRCO17, fmt.Sprintf("VAT category tax amount %s does not match expected %s (basis %s × rate %s ÷ 100)", tax.CalculatedAmount.String(), expected.String(), tax.BasisAmount.String(), tax.Percent.String()))
 		}

--- a/check_vat_igic.go
+++ b/check_vat_igic.go
@@ -89,7 +89,7 @@ func (inv *Invoice) checkVATIGIC() {
 	// VAT amount must equal basis * rate
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "L" {
-			expectedVAT := tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)).Round(2)
+			expectedVAT := roundHalfUp(tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)), 2)
 			if !tt.CalculatedAmount.Equal(expectedVAT) {
 				inv.addViolation(rules.BRAF6, fmt.Sprintf("IGIC VAT amount must equal basis * rate: got %s, expected %s", tt.CalculatedAmount.StringFixed(2), expectedVAT.StringFixed(2)))
 			}
@@ -129,7 +129,7 @@ func (inv *Invoice) checkVATIGIC() {
 	// For each different VAT rate, verify VAT amount calculation
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "L" {
-			expectedVAT := tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)).Round(2)
+			expectedVAT := roundHalfUp(tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)), 2)
 			if !tt.CalculatedAmount.Equal(expectedVAT) {
 				inv.addViolation(rules.BRAF8, fmt.Sprintf("IGIC VAT amount for rate %s must equal basis * rate: got %s, expected %s", tt.Percent.StringFixed(2), tt.CalculatedAmount.StringFixed(2), expectedVAT.StringFixed(2)))
 			}

--- a/check_vat_ipsi.go
+++ b/check_vat_ipsi.go
@@ -90,7 +90,7 @@ func (inv *Invoice) checkVATIPSI() {
 	// VAT amount must equal basis * rate
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "M" {
-			expectedVAT := tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)).Round(2)
+			expectedVAT := roundHalfUp(tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)), 2)
 			if !tt.CalculatedAmount.Equal(expectedVAT) {
 				inv.addViolation(rules.BRAG6, fmt.Sprintf("IPSI VAT amount must equal basis * rate: got %s, expected %s", tt.CalculatedAmount.StringFixed(2), expectedVAT.StringFixed(2)))
 			}
@@ -130,7 +130,7 @@ func (inv *Invoice) checkVATIPSI() {
 	// For each different VAT rate, verify VAT amount calculation
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "M" {
-			expectedVAT := tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)).Round(2)
+			expectedVAT := roundHalfUp(tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)), 2)
 			if !tt.CalculatedAmount.Equal(expectedVAT) {
 				inv.addViolation(rules.BRAG8, fmt.Sprintf("IPSI VAT amount for rate %s must equal basis * rate: got %s, expected %s", tt.Percent.StringFixed(2), tt.CalculatedAmount.StringFixed(2), expectedVAT.StringFixed(2)))
 			}

--- a/check_vat_standard.go
+++ b/check_vat_standard.go
@@ -159,7 +159,7 @@ func (inv *Invoice) checkVATStandard() {
 	// VAT amount must equal taxable amount * rate
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "S" {
-			expectedVAT := tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)).Round(2)
+			expectedVAT := roundHalfUp(tt.BasisAmount.Mul(tt.Percent).Div(decimal.NewFromInt(100)), 2)
 			if !tt.CalculatedAmount.Equal(expectedVAT) {
 				inv.addViolation(rules.BRS9, fmt.Sprintf("Standard rated VAT amount must equal basis * rate (expected %s, got %s)", expectedVAT.String(), tt.CalculatedAmount.String()))
 			}


### PR DESCRIPTION
Fixes #51

## Summary
This PR fixes the VAT rounding error where amounts were incorrectly using banker's rounding (round half to even) instead of commercial rounding (round half up) as required by the EN 16931 standard.

## Problem
The `UpdateApplicableTradeTax()` and validation functions were using Go's `decimal.Round()` which implements banker's rounding. This caused VAT amounts to round down when the third decimal was exactly 5, failing EN 16931 validation.

**Example:**
- Basis: 182,631.82 EUR at 19% VAT
- Calculation: 182,631.82 × 0.19 = 34,700.0458
- ❌ Before: 34,700.04 EUR (banker's rounding)
- ✅ After: 34,700.05 EUR (commercial rounding)

## Solution
- Added `roundHalfUp()` helper function that implements commercial rounding per EN 16931
- Updated `UpdateApplicableTradeTax()` to use `roundHalfUp` for VAT calculations
- Updated all VAT validation rules to use consistent rounding:
  - BR-CO-17 in check.go
  - BR-S-9 in check_vat_standard.go
  - BR-AF-6, BR-AF-8 in check_vat_igic.go
  - BR-AG-6, BR-AG-8 in check_vat_ipsi.go

## Tests
Added comprehensive test coverage:
- `TestUpdateApplicableTradeTax_RoundHalfUpVAT` - Tests the exact scenario from issue #51 plus edge cases
- `TestRoundHalfUp` - Direct tests of the rounding function with positive/negative values

All existing tests continue to pass ✓

## Files Changed
- `calculate.go` - Add roundHalfUp() and update VAT calculation
- `check.go` - Update BR-CO-17 validation
- `check_vat_standard.go` - Update BR-S-9 validation
- `check_vat_igic.go` - Update BR-AF-6, BR-AF-8 validations
- `check_vat_ipsi.go` - Update BR-AG-6, BR-AG-8 validations
- `calculate_test.go` - Add comprehensive tests