### PR TITLE
Fix rounding inconsistencies in VAT validation

### DIFF
--- a/validate_vat_exempt.go
+++ b/validate_vat_exempt.go
@@ -147,7 +147,7 @@ func (inv *Invoice) validateVATExempt() {
 					}
 				}
 			}
-			calculatedBasis = calculatedBasis.Round(2)
+			calculatedBasis = roundHalfUp(calculatedBasis, 2)
 			if !tt.BasisAmount.Equal(calculatedBasis) {
 				inv.addViolation(rules.BRE8, fmt.Sprintf("Exempt from VAT taxable amount must equal sum of line amounts (expected %s, got %s)", calculatedBasis.String(), tt.BasisAmount.String()))
 			}

--- a/validate_vat_export.go
+++ b/validate_vat_export.go
@@ -145,7 +145,7 @@ func (inv *Invoice) validateVATExport() {
 					}
 				}
 			}
-			calculatedBasis = calculatedBasis.Round(2)
+			calculatedBasis = roundHalfUp(calculatedBasis, 2)
 			if !tt.BasisAmount.Equal(calculatedBasis) {
 				inv.addViolation(rules.BRG8, fmt.Sprintf("Export outside EU taxable amount must equal sum of line amounts (expected %s, got %s)", calculatedBasis.String(), tt.BasisAmount.String()))
 			}

--- a/validate_vat_ic.go
+++ b/validate_vat_ic.go
@@ -121,7 +121,7 @@ func (inv *Invoice) validateVATIntracommunity() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
+			expectedBasis := roundHalfUp(lineTotal.Sub(allowanceTotal).Add(chargeTotal), 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRIC6, fmt.Sprintf("Intra-community supply taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -158,7 +158,7 @@ func (inv *Invoice) validateVATIntracommunity() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "K" {
 			key := tt.Percent.String()
-			expectedBasis := taxRateMap[key].Round(2)
+			expectedBasis := roundHalfUp(taxRateMap[key], 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRIC8, fmt.Sprintf("Intra-community supply taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/validate_vat_igic.go
+++ b/validate_vat_igic.go
@@ -78,7 +78,7 @@ func (inv *Invoice) validateVATIGIC() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
+			expectedBasis := roundHalfUp(lineTotal.Sub(allowanceTotal).Add(chargeTotal), 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAF5, fmt.Sprintf("IGIC taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -118,7 +118,7 @@ func (inv *Invoice) validateVATIGIC() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "L" {
 			key := tt.Percent.String()
-			expectedBasis := igicRateMap[key].Round(2)
+			expectedBasis := roundHalfUp(igicRateMap[key], 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAF7, fmt.Sprintf("IGIC taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/validate_vat_ipsi.go
+++ b/validate_vat_ipsi.go
@@ -79,7 +79,7 @@ func (inv *Invoice) validateVATIPSI() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
+			expectedBasis := roundHalfUp(lineTotal.Sub(allowanceTotal).Add(chargeTotal), 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAG5, fmt.Sprintf("IPSI taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -119,7 +119,7 @@ func (inv *Invoice) validateVATIPSI() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "M" {
 			key := tt.Percent.String()
-			expectedBasis := ipsiRateMap[key].Round(2)
+			expectedBasis := roundHalfUp(ipsiRateMap[key], 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRAG7, fmt.Sprintf("IPSI taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/validate_vat_notsubject.go
+++ b/validate_vat_notsubject.go
@@ -165,7 +165,7 @@ func (inv *Invoice) validateVATNotSubject() {
 					}
 				}
 			}
-			expectedBasis := lineTotal.Sub(allowanceTotal).Add(chargeTotal).Round(2)
+			expectedBasis := roundHalfUp(lineTotal.Sub(allowanceTotal).Add(chargeTotal), 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRO9, fmt.Sprintf("Not subject to VAT taxable amount mismatch: got %s, expected %s", tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}
@@ -194,7 +194,7 @@ func (inv *Invoice) validateVATNotSubject() {
 	for _, tt := range inv.TradeTaxes {
 		if tt.CategoryCode == "O" {
 			key := tt.Percent.String()
-			expectedBasis := notSubjectRateMap[key].Round(2)
+			expectedBasis := roundHalfUp(notSubjectRateMap[key], 2)
 			if !tt.BasisAmount.Equal(expectedBasis) {
 				inv.addViolation(rules.BRO10, fmt.Sprintf("Not subject to VAT taxable amount for rate %s: got %s, expected %s", tt.Percent.StringFixed(2), tt.BasisAmount.StringFixed(2), expectedBasis.StringFixed(2)))
 			}

--- a/validate_vat_reverse.go
+++ b/validate_vat_reverse.go
@@ -149,7 +149,7 @@ func (inv *Invoice) validateVATReverse() {
 					}
 				}
 			}
-			calculatedBasis = calculatedBasis.Round(2)
+			calculatedBasis = roundHalfUp(calculatedBasis, 2)
 			if !tt.BasisAmount.Equal(calculatedBasis) {
 				inv.addViolation(rules.BRAE8, fmt.Sprintf("Reverse charge taxable amount must equal sum of line amounts (expected %s, got %s)", calculatedBasis.String(), tt.BasisAmount.String()))
 			}

--- a/validate_vat_standard.go
+++ b/validate_vat_standard.go
@@ -147,8 +147,8 @@ func (inv *Invoice) validateVATStandard() {
 					}
 				}
 			}
-			// Round to 2 decimals for comparison
-			calculatedBasis = calculatedBasis.Round(2)
+			// Round to 2 decimals for comparison using commercial rounding (round half up)
+			calculatedBasis = roundHalfUp(calculatedBasis, 2)
 			if !tt.BasisAmount.Equal(calculatedBasis) {
 				inv.addViolation(rules.BRS8, fmt.Sprintf("Standard rated taxable amount must equal sum of line amounts for rate %s (expected %s, got %s)", tt.Percent.String(), calculatedBasis.String(), tt.BasisAmount.String()))
 			}

--- a/validate_vat_zero.go
+++ b/validate_vat_zero.go
@@ -147,7 +147,7 @@ func (inv *Invoice) validateVATZero() {
 					}
 				}
 			}
-			calculatedBasis = calculatedBasis.Round(2)
+			calculatedBasis = roundHalfUp(calculatedBasis, 2)
 			if !tt.BasisAmount.Equal(calculatedBasis) {
 				inv.addViolation(rules.BRZ8, fmt.Sprintf("Zero rated taxable amount must equal sum of line amounts (expected %s, got %s)", calculatedBasis.String(), tt.BasisAmount.String()))
 			}


### PR DESCRIPTION
## Summary
Fixes critical rounding inconsistency between VAT calculation and validation logic. Replaced `decimal.Round(2)` with `roundHalfUp()` in all VAT validation functions to ensure consistent use of commercial rounding (round half up) as required by EN 16931 specification.

## Problem
The calculation logic in `calculate.go` uses `roundHalfUp()` (commercial rounding) for VAT calculations, but the validation logic in various `validate_vat_*.go` files was using `decimal.Round(2)` (banker's rounding). This inconsistency caused false validation failures for edge cases.

**Example edge case:**
- Value: 34700.045
- Banker's rounding: 34700.04
- Commercial rounding: 34700.05

Since EN 16931 requires commercial rounding, the validation was incorrectly rejecting valid invoices.

## Changes
Fixed 13 rounding inconsistencies across 9 files:
- `validate_vat_standard.go`: BR-S-8 taxable amount validation (1 instance)
- `validate_vat_reverse.go`: BR-AE-8 taxable amount validation (1 instance)
- `validate_vat_exempt.go`: BR-E-8 taxable amount validation (1 instance)
- `validate_vat_zero.go`: BR-Z-8 taxable amount validation (1 instance)
- `validate_vat_export.go`: BR-G-8 taxable amount validation (1 instance)
- `validate_vat_notsubject.go`: BR-O-9, BR-O-10 taxable amount validations (2 instances)
- `validate_vat_ic.go`: BR-IC-6, BR-IC-8 taxable amount validations (2 instances)
- `validate_vat_igic.go`: BR-AF-5, BR-AF-7 taxable amount validations (2 instances)
- `validate_vat_ipsi.go`: BR-AG-5, BR-AG-7 taxable amount validations (2 instances)

## Testing
All existing tests pass successfully. The fix ensures that validation logic matches the calculation behavior, eliminating false positives in validation.

## Test plan
- [x] All existing unit tests pass
- [x] Rounding edge cases validated
- [x] EN 16931 compliance maintained