### PR TITLE
Add XRechnung 2.x profile support with explicit constants

### DIFF
--- a/model.go
+++ b/model.go
@@ -410,9 +410,17 @@ func (inv *Invoice) IsExtended() bool {
 }
 
 // IsXRechnung checks if the invoice uses the XRechnung profile.
-// URN: urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0
+// Supports XRechnung 2.0, 2.1, 2.2, 2.3, and 3.0.
+// URN examples:
+//   - urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0
+//   - urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1
 func (inv *Invoice) IsXRechnung() bool {
-	return inv.GuidelineSpecifiedDocumentContextParameter == SpecXRechnung30
+	urn := inv.GuidelineSpecifiedDocumentContextParameter
+	return urn == SpecXRechnung20 ||
+		urn == SpecXRechnung21 ||
+		urn == SpecXRechnung22 ||
+		urn == SpecXRechnung23 ||
+		urn == SpecXRechnung30
 }
 
 // ProfileLevel returns an integer representing the profile hierarchy level.

--- a/profile_constants.go
+++ b/profile_constants.go
@@ -88,12 +88,36 @@ const (
 	SpecEN16931 = "urn:cen.eu:en16931:2017"
 )
 
-// XRechnung Specification Identifier
+// XRechnung Specification Identifiers
 //
 // XRechnung is the German implementation of EN 16931, required for invoices to
 // German public sector entities. It adds German-specific business rules and
 // extensions to the base EN 16931 standard.
 const (
+	// SpecXRechnung20 is the XRechnung 2.0 specification identifier.
+	// Required for German public sector invoicing (B2G).
+	// This is EN 16931 compliant with German extensions.
+	// Version: 2.0
+	SpecXRechnung20 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0"
+
+	// SpecXRechnung21 is the XRechnung 2.1 specification identifier.
+	// Required for German public sector invoicing (B2G).
+	// This is EN 16931 compliant with German extensions.
+	// Version: 2.1
+	SpecXRechnung21 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1"
+
+	// SpecXRechnung22 is the XRechnung 2.2 specification identifier.
+	// Required for German public sector invoicing (B2G).
+	// This is EN 16931 compliant with German extensions.
+	// Version: 2.2
+	SpecXRechnung22 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2"
+
+	// SpecXRechnung23 is the XRechnung 2.3 specification identifier.
+	// Required for German public sector invoicing (B2G).
+	// This is EN 16931 compliant with German extensions.
+	// Version: 2.3
+	SpecXRechnung23 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3"
+
 	// SpecXRechnung30 is the XRechnung 3.0 specification identifier.
 	// Required for German public sector invoicing (B2G).
 	// This is EN 16931 compliant with German extensions.
@@ -110,7 +134,7 @@ func IsProfileURN(urn string) bool {
 	case SpecFacturXMinimum, SpecFacturXBasicWL, SpecFacturXBasic, SpecFacturXBasicAlt, SpecFacturXExtended,
 		SpecZUGFeRDMinimum, SpecZUGFeRDBasic, SpecZUGFeRDExtended,
 		SpecEN16931,
-		SpecXRechnung30:
+		SpecXRechnung20, SpecXRechnung21, SpecXRechnung22, SpecXRechnung23, SpecXRechnung30:
 		return true
 	default:
 		return false
@@ -140,6 +164,14 @@ func GetProfileName(urn string) string {
 		return "ZUGFeRD Extended"
 	case SpecEN16931:
 		return "EN 16931"
+	case SpecXRechnung20:
+		return "XRechnung 2.0"
+	case SpecXRechnung21:
+		return "XRechnung 2.1"
+	case SpecXRechnung22:
+		return "XRechnung 2.2"
+	case SpecXRechnung23:
+		return "XRechnung 2.3"
 	case SpecXRechnung30:
 		return "XRechnung 3.0"
 	default:


### PR DESCRIPTION
## Summary

Add support for XRechnung 2.0, 2.1, 2.2, and 2.3 profiles by adding explicit URN constants. Previously only XRechnung 3.0 was supported.

## Problem

The master branch only recognizes XRechnung 3.0:

```go
func (inv *Invoice) IsXRechnung() bool {
    return inv.GuidelineSpecifiedDocumentContextParameter == SpecXRechnung30
}
```

**Issues:**
- ❌ XRechnung 2.x invoices not recognized
- ❌ XRechnung 2.x invoices get `ProfileLevel()` = 0 (unknown)
- ❌ Missing profile constants for XRechnung 2.x versions

**Example:**
- `testdata/cii/xrechnung/zugferd-xrechnung-betriebskosten.xml` uses XRechnung 2.1
- Before: `ProfileLevel()` returns 0 (unknown)
- After: `ProfileLevel()` returns 4 (EN 16931 level)

## Solution

Add explicit constants for all XRechnung 2.x versions:

```go
const (
    SpecXRechnung20 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.0"
    SpecXRechnung21 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.1"
    SpecXRechnung22 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.2"
    SpecXRechnung23 = "urn:cen.eu:en16931:2017#compliant#urn:xoev-de:kosit:standard:xrechnung_2.3"
    SpecXRechnung30 = "urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0"
)

func (inv *Invoice) IsXRechnung() bool {
    urn := inv.GuidelineSpecifiedDocumentContextParameter
    return urn == SpecXRechnung20 ||
        urn == SpecXRechnung21 ||
        urn == SpecXRechnung22 ||
        urn == SpecXRechnung23 ||
        urn == SpecXRechnung30
}
```

## Changes

### `profile_constants.go`
- ✅ Add `SpecXRechnung20`, `SpecXRechnung21`, `SpecXRechnung22`, `SpecXRechnung23` constants
- ✅ Update `IsProfileURN()` to validate all XRechnung 2.x URNs
- ✅ Update `GetProfileName()` to return human-readable names for 2.x versions

### `model.go`
- ✅ Extend `IsXRechnung()` to check all XRechnung 2.x and 3.0 constants
- ✅ Document support for XRechnung 2.0-3.0 in comments
- ✅ Provide URN examples for both 2.x and 3.0 formats

## Impact

**Fixes XRechnung 2.x profile detection:**
- Before: `ProfileLevel()` returned 0 (unknown) for XRechnung 2.x invoices
- After: `ProfileLevel()` correctly returns 4 (EN 16931 level)

**Benefits:**
- ✅ XRechnung 2.0, 2.1, 2.2, 2.3 invoices now properly recognized
- ✅ Correct profile level enables proper field inclusion in writer
- ✅ Constants cleanly reusable throughout codebase
- ✅ Backward compatible (XRechnung 3.0 still works)
- ✅ No breaking changes

## Test Plan

- ✅ All existing tests pass
- ✅ XRechnung 2.1 invoices now correctly detected as profile level 4
- ✅ Full test suite passes
- ✅ No regressions

---

**Context:** Discovered while testing XRechnung 2.1 invoices. Profile detection was failing, causing incorrect ProfileLevel() results.