### PR TITLE
Fix CII writer to preserve product characteristics and classifications

### DIFF
--- a/writer_cii.go
+++ b/writer_cii.go
@@ -60,6 +60,28 @@ func writeCIIramIncludedSupplyChainTradeLineItem(invoiceLine InvoiceLine, inv *I
 		stp.CreateElement("ram:Description").SetText(invoiceLine.Description)
 	}
 
+	// Write product characteristics
+	for _, ch := range invoiceLine.Characteristics {
+		chElt := stp.CreateElement("ram:ApplicableProductCharacteristic")
+		chElt.CreateElement("ram:Description").SetText(ch.Description)
+		chElt.CreateElement("ram:Value").SetText(ch.Value)
+	}
+
+	// Write product classifications
+	for _, cl := range invoiceLine.ProductClassification {
+		clElt := stp.CreateElement("ram:DesignatedProductClassification")
+		if cl.ClassCode != "" {
+			ccElt := clElt.CreateElement("ram:ClassCode")
+			if cl.ListID != "" {
+				ccElt.CreateAttr("listID", cl.ListID)
+			}
+			if cl.ListVersionID != "" {
+				ccElt.CreateAttr("listVersionID", cl.ListVersionID)
+			}
+			ccElt.SetText(cl.ClassCode)
+		}
+	}
+
 	slta := lineItem.CreateElement("ram:SpecifiedLineTradeAgreement")
 
 	// BT-148


### PR DESCRIPTION
## Summary

- Fixes data loss in CII writer for product characteristics and classifications
- CII parser reads these fields correctly, but writer was not outputting them
- Adds writing logic for `ram:ApplicableProductCharacteristic` and `ram:DesignatedProductClassification`

## Problem

The CII parser in `parser_cii.go` correctly reads product metadata from XML:
- `ram:ApplicableProductCharacteristic` (Description + Value)
- `ram:DesignatedProductClassification` (ClassCode with listID/listVersionID attributes)

However, `writer_cii.go` was missing the corresponding writer logic, causing data loss during round-trip operations (Parse → Write → Parse).

## Solution

Added writer code in `writeCIIramIncludedSupplyChainTradeLineItem()` to output both:
1. **Product Characteristics**: Loops through `invoiceLine.Characteristics` and writes `ram:ApplicableProductCharacteristic` elements
2. **Product Classifications**: Loops through `invoiceLine.ProductClassification` and writes `ram:DesignatedProductClassification` elements with proper attributes

## Test Case

Fixes round-trip test failure for `testdata/cii/en16931/CII_example9.xml` which contains:
```xml
<ram:ApplicableProductCharacteristic>
  <ram:Description>Verbruikscategorie</ram:Description>
  <ram:Value>Start</ram:Value>
</ram:ApplicableProductCharacteristic>
```

The invoice can now be parsed, written, and re-parsed without data loss.