### PR TITLE
Fix CII writer missing fields causing round-trip data loss

### DIFF
--- a/writer_cii.go
+++ b/writer_cii.go
@@ -82,6 +82,12 @@ func writeCIIramIncludedSupplyChainTradeLineItem(invoiceLine InvoiceLine, inv *I
 		}
 	}
 
+	// BT-159: Item country of origin
+	if invoiceLine.OriginTradeCountry != "" {
+		otc := stp.CreateElement("ram:OriginTradeCountry")
+		otc.CreateElement("ram:ID").SetText(invoiceLine.OriginTradeCountry)
+	}
+
 	slta := lineItem.CreateElement("ram:SpecifiedLineTradeAgreement")
 
 	// BT-148
@@ -286,6 +292,12 @@ func writeCIIramApplicableHeaderTradeAgreement(inv *Invoice, parent *etree.Eleme
 
 	writeCIIParty(inv, inv.Seller, elt.CreateElement("ram:SellerTradeParty"), CSellerParty)
 	writeCIIParty(inv, inv.Buyer, elt.CreateElement("ram:BuyerTradeParty"), CBuyerParty)
+
+	// BG-11: Seller tax representative party
+	if inv.SellerTaxRepresentativeTradeParty != nil {
+		writeCIIParty(inv, *inv.SellerTaxRepresentativeTradeParty, elt.CreateElement("ram:SellerTaxRepresentativeTradeParty"), CSellerParty)
+	}
+
 	// BT-13
 	if inv.BuyerOrderReferencedDocument != "" {
 		elt.CreateElement("ram:BuyerOrderReferencedDocument").CreateElement("ram:IssuerAssignedID").SetText(inv.BuyerOrderReferencedDocument)
@@ -376,7 +388,13 @@ func writeCIIramApplicableHeaderTradeSettlement(inv *Invoice, parent *etree.Elem
 	elt := parent.CreateElement("ram:ApplicableHeaderTradeSettlement")
 	// CreditorReferenceID BT-90
 	// PaymentReference BT-83
-	// TaxCurrencyCode BT-6
+
+	// BT-6: VAT accounting currency code (optional, when different from invoice currency)
+	if inv.TaxCurrencyCode != "" && inv.TaxCurrencyCode != inv.InvoiceCurrencyCode {
+		elt.CreateElement("ram:TaxCurrencyCode").SetText(inv.TaxCurrencyCode)
+	}
+
+	// BT-5: Invoice currency code (required)
 	elt.CreateElement("ram:InvoiceCurrencyCode").SetText(inv.InvoiceCurrencyCode)
 
 	// PayeeTradeParty BG-10


### PR DESCRIPTION
## Summary

This PR fixes three missing fields in the CII (ZUGFeRD/Factur-X) writer that were causing data loss in round-trip tests (Parse → Write → Parse).

## Changes

### 1. BT-159: Item country of origin (`OriginTradeCountry`)
- **Location**: `writeCIIramIncludedSupplyChainTradeLineItem()`
- **Issue**: Field was correctly parsed but not written back
- **Fix**: Added `ram:OriginTradeCountry/ram:ID` element writing for line items
- **Example**: `<ram:OriginTradeCountry><ram:ID>DE</ram:ID></ram:OriginTradeCountry>`

### 2. BG-11: Seller tax representative party (`SellerTaxRepresentativeTradeParty`)
- **Location**: `writeCIIramApplicableHeaderTradeAgreement()`
- **Issue**: Field was correctly parsed but not written back
- **Fix**: Added full party element writing using `writeCIIParty()` helper
- **Note**: Uses `CSellerParty` type to ensure postal address is always written
- **Example**: 
  ```xml
  <ram:SellerTaxRepresentativeTradeParty>
    <ram:Name>Tax Representative Name</ram:Name>
    <ram:PostalTradeAddress>...</ram:PostalTradeAddress>
    <ram:SpecifiedTaxRegistration>
      <ram:ID schemeID="VA">DE987654321</ram:ID>
    </ram:SpecifiedTaxRegistration>
  </ram:SellerTaxRepresentativeTradeParty>
  ```

### 3. BT-6: VAT accounting currency code (`TaxCurrencyCode`)
- **Location**: `writeCIIramApplicableHeaderTradeSettlement()`
- **Issue**: Field was correctly parsed but not written back
- **Fix**: Added `ram:TaxCurrencyCode` writing (only when different from invoice currency)
- **Example**: `<ram:TaxCurrencyCode>EUR</ram:TaxCurrencyCode>`

## Testing

All three fields were detected missing by round-trip tests that compare original parsed invoices with re-parsed written output:
- ✅ `testdata/cii/extended/zugferd-extended-intra-community-multi.xml` - Now passes (previously failed on fields 1 & 2)
- ✅ `testdata/cii/extended/zugferd-extended-fremdwaehrung.xml` - Now passes (previously failed on field 3)

## Notes

- The CII parser already correctly reads all three fields
- The UBL writer already had all three fields implemented correctly
- These were CII writer-specific omissions
- All fixes follow existing code patterns and EN 16931 specification