### PR TITLE
Fix TradingBusinessName data loss in CII and UBL writers

### DIFF
--- a/writer_cii.go
+++ b/writer_cii.go
@@ -223,6 +223,9 @@ func writeCIIParty(inv *Invoice, party Party, parent *etree.Element, partyType C
 		id := sloElt.CreateElement("ram:ID")
 		id.CreateAttr("schemeID", slo.Scheme)
 		id.SetText(slo.ID)
+		if slo.TradingBusinessName != "" {
+			sloElt.CreateElement("ram:TradingBusinessName").SetText(slo.TradingBusinessName)
+		}
 	}
 
 	for _, dtc := range party.DefinedTradeContact {

--- a/writer_ubl.go
+++ b/writer_ubl.go
@@ -293,7 +293,10 @@ func writeUBLParty(parent *etree.Element, party Party, isSeller bool) {
 	// Legal organization
 	if party.SpecifiedLegalOrganization != nil {
 		legalEntity := parent.CreateElement("cac:PartyLegalEntity")
-		legalEntity.CreateElement("cbc:RegistrationName").SetText(party.Name)
+		// BT-27: Seller legal registration name (TradingBusinessName)
+		if party.SpecifiedLegalOrganization.TradingBusinessName != "" {
+			legalEntity.CreateElement("cbc:RegistrationName").SetText(party.SpecifiedLegalOrganization.TradingBusinessName)
+		}
 
 		if party.SpecifiedLegalOrganization.ID != "" {
 			companyID := legalEntity.CreateElement("cbc:CompanyID")


### PR DESCRIPTION
## Summary

Fixes round-trip data loss for `TradingBusinessName` (BT-27 - Seller legal registration name) in both CII and UBL writers. The parsers correctly read this field, but the writers were either omitting it entirely (CII) or writing the wrong field (UBL).

## Problem

### CII Writer
- **Issue**: `TradingBusinessName` was parsed correctly but never written out
- **Impact**: Field lost during Parse → Write → Parse cycle
- **Test case**: `testdata/cii/en16931/CII_example7.xml`
  - Expected: "Civic Service Centre"
  - Actual after round-trip: "" (empty)

### UBL Writer
- **Issue**: Writer used `party.Name` instead of `party.SpecifiedLegalOrganization.TradingBusinessName` for `cbc:RegistrationName`
- **Impact**: Wrong value written (BT-28 instead of BT-27)
- **Test case**: `testdata/ubl/invoice/ubl-tc434-example7.xml`
  - Expected: "The Sellercompany Incorporated"
  - Actual after round-trip: "Civic Service Centre" (wrong value from party.Name)

## EN 16931 Mapping

- **BT-27**: Seller legal registration name → `TradingBusinessName`
- **BT-28**: Seller trading name → `Name`

**In UBL:**
- `cac:PartyLegalEntity/cbc:RegistrationName` = BT-27 = `TradingBusinessName`
- `cac:PartyName/cbc:Name` = BT-28 = `Name`

**In CII:**
- `ram:SpecifiedLegalOrganization/ram:TradingBusinessName` = BT-27 = `TradingBusinessName`
- `ram:Name` = BT-28 = `Name`

## Changes

### writer_cii.go (lines 226-228)
Added missing `TradingBusinessName` element output:
```go
if slo.TradingBusinessName != "" {
    sloElt.CreateElement("ram:TradingBusinessName").SetText(slo.TradingBusinessName)
}
```

### writer_ubl.go (lines 296-299)
Fixed to use correct field for `cbc:RegistrationName`:
```go
// BT-27: Seller legal registration name (TradingBusinessName)
if party.SpecifiedLegalOrganization.TradingBusinessName != "" {
    legalEntity.CreateElement("cbc:RegistrationName").SetText(party.SpecifiedLegalOrganization.TradingBusinessName)
}
```

## Testing

Both test fixtures now pass round-trip validation:

```bash
# CII test
go test -run "TestAllValidFixtures/testdata/cii/en16931/CII_example7.xml" -v
# PASS ✅

# UBL test  
go test -run "TestAllValidFixtures/testdata/ubl/invoice/ubl-tc434-example7.xml" -v
# PASS ✅
```

## Impact

This fix is critical for:
- **Legal/compliance requirements** where company legal registration names must be preserved
- **Round-trip data integrity** when parsing, modifying, and re-writing invoices
- **Interoperability** with systems that rely on BT-27 for legal entity identification

Affects any invoice with a legal organization where the legal registration name differs from the trading name (common in companies with DBAs, subsidiaries, or localized trading names).

## Related

- Discovered by comprehensive round-trip integration tests (PR #98)
- Parsers (`parser_cii.go`, `parser_ubl.go`) already correctly read this field
- Only writers needed fixing