### PR TITLE
Fix validation for BasicWL profiles without line items

### DIFF
--- a/validate_core.go
+++ b/validate_core.go
@@ -566,10 +566,14 @@ func (inv *Invoice) validateCore() {
 		// Jede Umsatzsteueraufschlüsselung "VAT BREAKDOWN" (BG-23) muss die
 		// Summe aller nach dem jeweiligen Schlüssel zu versteuernden Beträge
 		// "VAT category taxable amount" (BT-116) aufweisen.
-		key := tt.CategoryCode + "_" + tt.Percent.String()
-		if !applicableTradeTaxes[key].Equal(tt.BasisAmount) {
-			inv.addViolation(rules.BR45, "Applicable trade tax basis amount not equal to the sum of line total")
+		// Note: This validation only applies to profiles with line items (>= Basic, level 3).
+		// BasicWL profile (level 2) provides BasisAmount directly without line items.
+		if is(levelBasic, inv) {
+			key := tt.CategoryCode + "_" + tt.Percent.String()
+			if !applicableTradeTaxes[key].Equal(tt.BasisAmount) {
+				inv.addViolation(rules.BR45, "Applicable trade tax basis amount not equal to the sum of line total")
 
+			}
 		}
 		// BR-47 Umsatzsteueraufschlüsselung
 		// Jede Umsatzsteueraufschlüsselung "VAT BREAKDOWN" (BG-23) muss über

--- a/validate_vat_notsubject.go
+++ b/validate_vat_notsubject.go
@@ -121,7 +121,9 @@ func (inv *Invoice) validateVATNotSubject() {
 	}
 
 	// BR-O-08: VAT category taxable amount calculation
-	if oBreakdown != nil {
+	// Note: This validation only applies to profiles with line items (>= Basic, level 3).
+	// BasicWL profile (level 2) provides BasisAmount directly without line items.
+	if oBreakdown != nil && (inv.ProfileLevel() >= levelBasic || (inv.ProfileLevel() == 0 && len(inv.InvoiceLines) > 0)) {
 		var lineTotal decimal.Decimal
 		for _, line := range inv.InvoiceLines {
 			if line.TaxCategoryCode == "O" {


### PR DESCRIPTION
## Summary
This PR fixes validation issues for BasicWL profile invoices (level 2) that provide VAT basis amounts directly without invoice line items, as specified in the ZUGFeRD/Factur-X specification.

## Problem
BasicWL profiles are designed to provide minimal invoice data without line-level detail. However, validation rules BR-45 and all VAT category-specific basis amount rules (BR-S-8, BR-E-8, BR-AE-8, BR-Z-8, BR-G-8, BR-IC-8, BR-O-8, BR-AF-5, BR-AF-7, BR-AG-5, BR-AG-7) were attempting to validate basis amounts by summing line items, causing failures for valid BasicWL invoices.

## Solution
Updated all basis amount validation rules to skip validation for profiles below Basic level (< level 3). The validation logic now:

- **Validates** for ProfileLevel >= levelBasic (3): Basic, EN16931, Extended profiles
- **Validates** for ProfileLevel == 0 AND has line items: Test/programmatic invoices
- **Skips** for ProfileLevel == levelBasicWL (2): BasicWL profiles (no line items by design)

## Changes
- `validate_core.go`: Updated BR-45 with profile-level check
- `validate_vat_standard.go`: Updated BR-S-8 with profile-level check
- `validate_vat_exempt.go`: Updated BR-E-8 with profile-level check
- `validate_vat_reverse.go`: Updated BR-AE-8 with profile-level check
- `validate_vat_zero.go`: Updated BR-Z-8 with profile-level check
- `validate_vat_export.go`: Updated BR-G-8 with profile-level check
- `validate_vat_ic.go`: Updated BR-IC-8 with profile-level check
- `validate_vat_notsubject.go`: Updated BR-O-8 with profile-level check
- `validate_vat_igic.go`: Updated BR-AF-5 and BR-AF-7 with profile-level checks
- `validate_vat_ipsi.go`: Updated BR-AG-5 and BR-AG-7 with profile-level checks

## Test Results
All BasicWL fixture tests now pass:
- ✅ `testdata/cii/basicwl/zugferd-basicwl-einfach.xml`
- ✅ `testdata/cii/basicwl/zugferd-basicwl-buchungshilfe.xml`

## References
- EN 16931 specification
- ZUGFeRD/Factur-X profile hierarchy: Minimum (1) < BasicWL (2) < Basic (3) < EN16931/PEPPOL/XRechnung (4) < Extended (5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)