### PR TITLE
Fix round-trip preservation for URIUniversalCommunicationScheme and BasisQuantityUnit

### DIFF
--- a/writer_cii.go
+++ b/writer_cii.go
@@ -278,7 +278,8 @@ func writeCIIParty(inv *Invoice, party Party, parent *etree.Element, partyType C
 	}
 
 	// BT-34, BT-49: Electronic address (URI Universal Communication)
-	if party.URIUniversalCommunication != "" {
+	// Write element if either value or scheme is present
+	if party.URIUniversalCommunication != "" || party.URIUniversalCommunicationScheme != "" {
 		uuc := parent.CreateElement("ram:URIUniversalCommunication")
 		uriID := uuc.CreateElement("ram:URIID")
 		if party.URIUniversalCommunicationScheme != "" {


### PR DESCRIPTION
## Summary

This PR fixes two round-trip issues where parsed XML data would not match the original after being written back out.

## Changes

### 1. URIUniversalCommunicationScheme (BT-34, BT-49)

**Problem:** When an XML element had `schemeID` attribute but empty/missing value, the parser correctly captured the scheme, but the writers wouldn't output the element at all (losing the schemeID).

**Original XML:**
```xml
<!-- CII -->
<ram:URIUniversalCommunication>
  <ram:URIID schemeID="EM" />
</ram:URIUniversalCommunication>

<!-- UBL -->
<cbc:EndpointID schemeID="0192">987654325</cbc:EndpointID>
```

**Fix:** Writers now output the element when either value OR scheme is present.

**Files changed:**
- `writer_cii.go:282` - Updated condition to check for scheme presence
- `writer_ubl.go:242` - Updated condition to check for scheme presence

### 2. BasisQuantityUnit (BT-149)

**Problem:** When `BaseQuantity` element lacked `unitCode` attribute, the UBL writer would add one by falling back to `BilledQuantityUnit`, creating data that wasn't in the original.

**Original XML:**
```xml
<cbc:BaseQuantity>1</cbc:BaseQuantity>  <!-- No unitCode attribute -->
```

**Fix:** Removed fallback to `BilledQuantityUnit`, only write `unitCode` if `BasisQuantityUnit` was explicitly set.

**Files changed:**
- `writer_ubl.go:722` - Removed fallback logic

## Specification Compliance

Both fixes maintain EN 16931 compliance:
- **URIUniversalCommunicationScheme:** An electronic address with a scheme identifier is valid for routing/validation purposes
- **BasisQuantityUnit:** EN 16931 doesn't mandate `unitCode` on BT-149 (BaseQuantity), making it optional

## Testing

Round-trip tests now pass for:
- ✅ `testdata/cii/xrechnung/XRechnung-O.xml`
- ✅ `testdata/peppol/valid/Norwegian-example-1.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)