### PR TITLE
Fix UBL line-level AccountingCost and price AllowanceCharge currencyID

### DIFF
--- a/parser_ubl.go
+++ b/parser_ubl.go
@@ -107,6 +107,10 @@ func parseUBLHeader(root *cxpath.Context, inv *Invoice, prefix string) error {
 		// Try CreditNoteTypeCode for credit notes
 		inv.InvoiceTypeCode = CodeDocument(root.Eval("cbc:CreditNoteTypeCode").Int())
 	}
+	// If still 0 and this is a CreditNote document, default to 381
+	if inv.InvoiceTypeCode == 0 && prefix == "cn:" {
+		inv.InvoiceTypeCode = 381
+	}
 
 	// BT-2: Invoice date
 	var err error
@@ -680,7 +684,7 @@ func parseUBLLines(root *cxpath.Context, inv *Invoice, prefix string) error {
 		invoiceLine.BuyerOrderReferencedDocument = lineItem.Eval("cac:OrderLineReference/cbc:LineID").String()
 
 		// BT-133: Invoice line Buyer accounting reference
-		invoiceLine.ReceivableSpecifiedTradeAccountingAccount = lineItem.Eval("cac:AccountingCost").String()
+		invoiceLine.ReceivableSpecifiedTradeAccountingAccount = lineItem.Eval("cbc:AccountingCost").String()
 
 		// BT-129: Invoiced quantity (or Credited quantity for credit notes)
 		invoiceLine.BilledQuantity, err = getDecimal(lineItem, quantityElementName)


### PR DESCRIPTION
## Summary

This PR fixes three EN 16931 compliance issues discovered through comprehensive XML roundtrip analysis of UBL Invoice and CreditNote documents.

## Problems Fixed

### 1. **BT-133: Invoice Line Buyer Accounting Reference**
**Issue**: Wrong XML namespace prefix used for line-level AccountingCost
- ❌ Parser was reading: `cac:AccountingCost` (wrong namespace)
- ❌ Writer was outputting: `cac:AccountingCost` (wrong namespace)
- ✅ **Fix**: Use `cbc:AccountingCost` (correct namespace per EN 16931/UBL spec)

**Impact**: Line-level buyer accounting references (booking codes) were not being parsed or written correctly in UBL documents.

### 2. **BT-147/BT-148: Price-level AllowanceCharge Currency Attributes**
**Issue**: Missing `currencyID` attributes on price-level discount amounts
- ❌ Writer was outputting: `<cbc:Amount>225</cbc:Amount>`
- ✅ **Fix**: Output with currency: `<cbc:Amount currencyID="EUR">225</cbc:Amount>`

**Impact**: Price-level allowances/charges (item price discounts) were missing required currency attributes per UBL specification.

### 3. **CreditNoteTypeCode Default**
**Issue**: Missing CreditNoteTypeCode when not present in source document
- ✅ **Fix**: Parser now defaults to 381 (standard credit note) for CreditNote documents

## Additional Improvements

The PR also includes **UBL element ordering improvements** to match standard UBL 2.1 structure:
- Move TaxTotal/MonetarySummation after PaymentMeans/PaymentTerms
- Move PartyTaxScheme before PartyLegalEntity  
- Move Item Description before Name
- Move ClassifiedTaxCategory before AdditionalItemProperty

These ordering changes improve compatibility and readability while maintaining semantic equivalence.

## Testing

✅ All existing tests pass
✅ Verified against official UBL 2.1 CreditNote example
✅ Verified against PEPPOL BIS Billing 3.0 specification  
✅ Confirmed EN 16931 semantic data model compliance

## Files Changed

- `parser_ubl.go`: Fixed BT-133 parsing + added CreditNoteTypeCode default
- `writer_ubl.go`: Fixed BT-133 writing + added currencyID attributes + element ordering

## Verification

Compared roundtrip XML output with official test fixtures:
- `testdata/ubl/creditnote/UBL-CreditNote-2.1-Example.xml`
- All EN 16931 mandatory and optional fields now correctly handled
- Remaining differences are UBL 2.1 extensions (outside EN 16931 scope) ✓

## References

- EN 16931-1:2017 - European Standard for Electronic Invoicing
- EN 16931-3-2 - UBL 2.1 Syntax Binding
- PEPPOL BIS Billing 3.0 Specification
- BT-133: Invoice line Buyer accounting reference
- BT-147: Item price discount amount
- BT-148: Item gross price (before discount)