### PR TITLE
Fix decimal precision validation for programmatically built invoices

### DIFF
--- a/calculate.go
+++ b/calculate.go
@@ -117,6 +117,11 @@ func (inv *Invoice) updateAllowancesAndCharges() {
 			inv.AllowanceTotal = inv.AllowanceTotal.Add(ac.ActualAmount)
 		}
 	}
+
+	// BR-DEC-10: AllowanceTotal (BT-107) must have max 2 decimal places
+	inv.AllowanceTotal = roundHalfUp(inv.AllowanceTotal, 2)
+	// BR-DEC-11: ChargeTotal (BT-108) must have max 2 decimal places
+	inv.ChargeTotal = roundHalfUp(inv.ChargeTotal, 2)
 }
 
 // UpdateTotals recalculates all monetary totals according to EN 16931 business rules.
@@ -146,6 +151,8 @@ func (inv *Invoice) UpdateTotals() {
 	for _, line := range inv.InvoiceLines {
 		inv.LineTotal = inv.LineTotal.Add(line.Total)
 	}
+	// BR-DEC-09: LineTotal (BT-106) must have max 2 decimal places
+	inv.LineTotal = roundHalfUp(inv.LineTotal, 2)
 
 	// BR-CO-11 & BR-CO-12: Calculate allowance and charge totals from document-level items
 	inv.updateAllowancesAndCharges()
@@ -155,13 +162,21 @@ func (inv *Invoice) UpdateTotals() {
 	for _, v := range inv.TradeTaxes {
 		inv.TaxTotal = inv.TaxTotal.Add(v.CalculatedAmount)
 	}
+	// BR-DEC-13: TaxTotal (BT-110) must have max 2 decimal places
+	inv.TaxTotal = roundHalfUp(inv.TaxTotal, 2)
 
 	// BR-CO-13: TaxBasisTotal = LineTotal - AllowanceTotal + ChargeTotal
 	inv.TaxBasisTotal = inv.LineTotal.Sub(inv.AllowanceTotal).Add(inv.ChargeTotal)
+	// BR-DEC-12: TaxBasisTotal (BT-109) must have max 2 decimal places
+	inv.TaxBasisTotal = roundHalfUp(inv.TaxBasisTotal, 2)
 
 	// BR-CO-15: GrandTotal = TaxBasisTotal + TaxTotal
 	inv.GrandTotal = inv.TaxBasisTotal.Add(inv.TaxTotal)
+	// BR-DEC-14: GrandTotal (BT-112) must have max 2 decimal places
+	inv.GrandTotal = roundHalfUp(inv.GrandTotal, 2)
 
 	// BR-CO-16: DuePayableAmount = GrandTotal - TotalPrepaid + RoundingAmount
 	inv.DuePayableAmount = inv.GrandTotal.Sub(inv.TotalPrepaid).Add(inv.RoundingAmount)
+	// BR-DEC-18: DuePayableAmount (BT-115) must have max 2 decimal places
+	inv.DuePayableAmount = roundHalfUp(inv.DuePayableAmount, 2)
 }


### PR DESCRIPTION
## Summary

Fixes decimal precision validation errors (BR-DEC-*) that occur when building invoices programmatically. When monetary calculations produce values with more than 2 decimal places, the validation would fail even though the values were correct.

## Problem

When building invoices programmatically (as opposed to parsing from XML), monetary calculations could produce values with excess decimal precision:
- Example: `166.5 × 4.25 = 707.625` (3 decimal places)
- This would fail `BR-DEC-09` validation: "Sum of Invoice line net amount (BT-106) has more than 2 decimal places: 707.625"

XML-parsed invoices don't have this issue because string-parsed decimals (e.g., "707.63") maintain their precision as written.

The issue stems from the decimal library's internal representation: `decimal.Decimal` stores an exponent indicating precision, and the validation checks this exponent rather than just the displayed value.

## Solution

Modified `UpdateTotals()` and `updateAllowancesAndCharges()` to round all calculated monetary totals to 2 decimal places using the existing `roundHalfUp()` function.

**Changes in `calculate.go`:**
- `UpdateTotals()`: Added rounding for LineTotal (BT-106), TaxTotal (BT-110), TaxBasisTotal (BT-109), GrandTotal (BT-112), and DuePayableAmount (BT-115)
- `updateAllowancesAndCharges()`: Added rounding for AllowanceTotal (BT-107) and ChargeTotal (BT-108)

## Business Rules Affected

This ensures compliance with EN 16931 decimal precision requirements:
- BR-DEC-09: Sum of Invoice line net amount (BT-106)
- BR-DEC-10: Sum of allowances on document level (BT-107)
- BR-DEC-11: Sum of charges on document level (BT-108)
- BR-DEC-12: Invoice total amount without VAT (BT-109)
- BR-DEC-13: Invoice total VAT amount (BT-110)
- BR-DEC-14: Invoice total amount with VAT (BT-112)
- BR-DEC-18: Amount due for payment (BT-115)

## Testing

All existing tests pass. The fix maintains backward compatibility while ensuring programmatically built invoices have the same precision as XML-parsed invoices.

## Example

Before this fix:
```go
price := decimal.NewFromString("166.5")
quantity := decimal.NewFromString("4.25")
line.Total = price.Mul(quantity)  // 707.625 (exponent -3) ❌ fails validation

inv.UpdateTotals()
// inv.LineTotal = 707.625 (still 3 decimals) ❌
```

After this fix:
```go
price := decimal.NewFromString("166.5")
quantity := decimal.NewFromString("4.25")
line.Total = price.Mul(quantity)  // 707.625 (exponent -3)

inv.UpdateTotals()
// inv.LineTotal = 707.63 (rounded to 2 decimals) ✅ passes validation
```