### PR TITLE
[BR-O-05] When VAT category code is "O", invoice lines should not contain RateApplicablePercent

### DIFF
--- a/model.go
+++ b/model.go
@@ -227,9 +227,10 @@ type InvoiceLine struct {
 
 	// Private fields for tracking XML element presence (BR-24, BR-26, BR-CO-20)
 	// These are set during parsing to distinguish between missing elements and zero values
-	hasLineTotalInXML bool
-	hasNetPriceInXML  bool
-	linePeriodPresent bool // true if BG-26 (INVOICE LINE PERIOD) was present in source XML
+	hasLineTotalInXML           bool
+	hasNetPriceInXML            bool
+	hasTaxRateApplicablePercent bool
+	linePeriodPresent           bool // true if BG-26 (INVOICE LINE PERIOD) was present in source XML
 }
 
 // PaymentMeans represents a payment means.

--- a/parser_cii.go
+++ b/parser_cii.go
@@ -223,6 +223,7 @@ func parseCIISupplyChainTradeTransaction(supplyChainTradeTransaction *cxpath.Con
 		if err != nil {
 			return err
 		}
+		invoiceLine.hasTaxRateApplicablePercent = taxInfo.Eval("count(ram:RateApplicablePercent)").Int() > 0
 		// BR-CO-20: Track BG-26 (INVOICE LINE PERIOD) presence to validate later
 		invoiceLine.linePeriodPresent = lineItem.Eval("count(ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod)").Int() > 0
 		invoiceLine.BillingSpecifiedPeriodStart, err = parseCIITime(lineItem, "ram:SpecifiedLineTradeSettlement/ram:BillingSpecifiedPeriod/ram:StartDateTime/udt:DateTimeString")

--- a/parser_ubl.go
+++ b/parser_ubl.go
@@ -771,6 +771,7 @@ func parseUBLLines(root *cxpath.Context, inv *Invoice, prefix string) error {
 		if err != nil {
 			return err
 		}
+		invoiceLine.hasTaxRateApplicablePercent = taxInfo.Eval("count(cbc:Percent)").Int() > 0
 
 		inv.InvoiceLines = append(inv.InvoiceLines, invoiceLine)
 	}

--- a/validate_vat_notsubject.go
+++ b/validate_vat_notsubject.go
@@ -101,7 +101,10 @@ func (inv *Invoice) validateVATNotSubject() {
 
 	// BR-O-05: Invoice lines with category O must NOT contain VAT rate
 	for i := range inv.InvoiceLines {
-		if inv.InvoiceLines[i].TaxCategoryCode == "O" && !inv.InvoiceLines[i].TaxRateApplicablePercent.IsZero() {
+		if inv.InvoiceLines[i].TaxCategoryCode != "O" {
+			continue
+		}
+		if !inv.InvoiceLines[i].TaxRateApplicablePercent.IsZero() || inv.InvoiceLines[i].hasTaxRateApplicablePercent {
 			inv.addViolation(rules.BRO5, "Invoice line with 'Not subject to VAT' shall not contain VAT rate (BT-152)")
 		}
 	}

--- a/validate_vat_notsubject_test.go
+++ b/validate_vat_notsubject_test.go
@@ -246,6 +246,44 @@ func TestBRO5_LineNoVATRate(t *testing.T) {
 	}
 }
 
+// TestBRO5_LineNoVATRate_parsed tests BR-O-05: Invoice lines with category O must NOT contain VAT rate, even if empty or 0
+func TestBRO5_LineNoVATRate_parsed(t *testing.T) {
+	t.Parallel()
+
+	inv := Invoice{
+		InvoiceLines: []InvoiceLine{
+			{
+				TaxCategoryCode:             "O",
+				TaxRateApplicablePercent:    decimal.Zero,
+				Total:                       decimal.NewFromInt(100),
+				hasTaxRateApplicablePercent: true,
+			},
+		},
+		TradeTaxes: []TradeTax{
+			{
+				CategoryCode:     "O",
+				BasisAmount:      decimal.NewFromInt(100),
+				CalculatedAmount: decimal.Zero,
+				ExemptionReason:  "Not subject to VAT",
+			},
+		},
+	}
+
+	_ = inv.Validate()
+
+	found := false
+	for _, v := range inv.violations {
+		if v.Rule.Code == "BR-O-05" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("Expected BR-O-05 violation for line with VAT rate in Not subject to VAT")
+	}
+}
+
 // TestBRO6_AllowanceNoVATRate tests BR-O-06: Allowances with category O must NOT contain VAT rate
 func TestBRO6_AllowanceNoVATRate(t *testing.T) {
 	t.Parallel()

--- a/writer_cii.go
+++ b/writer_cii.go
@@ -165,7 +165,9 @@ func writeCIIramIncludedSupplyChainTradeLineItem(invoiceLine *InvoiceLine, inv *
 
 	att.CreateElement("ram:TypeCode").SetText(invoiceLine.TaxTypeCode)
 	att.CreateElement("ram:CategoryCode").SetText(invoiceLine.TaxCategoryCode)
-	att.CreateElement("ram:RateApplicablePercent").SetText(formatPercent(invoiceLine.TaxRateApplicablePercent))
+	if invoiceLine.TaxCategoryCode != "O" {
+		att.CreateElement("ram:RateApplicablePercent").SetText(formatPercent(invoiceLine.TaxRateApplicablePercent))
+	}
 
 	// BG-26: Invoice line period (BT-134, BT-135)
 	if !invoiceLine.BillingSpecifiedPeriodStart.IsZero() || !invoiceLine.BillingSpecifiedPeriodEnd.IsZero() {

--- a/writer_cii_test.go
+++ b/writer_cii_test.go
@@ -116,6 +116,113 @@ func TestWrite_PayeeTradeParty(t *testing.T) {
 	}
 }
 
+func TestWrite_RoundTrip(t *testing.T) {
+	original := &Invoice{
+		SchemaType: CII,
+		GuidelineSpecifiedDocumentContextParameter: SpecEN16931,
+		InvoiceNumber:       "INV-RoundTrip",
+		InvoiceTypeCode:     380,
+		InvoiceDate:         time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		InvoiceCurrencyCode: "EUR",
+		BuyerReference:      "REF-123",
+		Seller: Party{
+			Name: "Test Seller",
+			PostalAddress: &PostalAddress{
+				CountryID:    "DE",
+				PostcodeCode: "10115",
+				City:         "Berlin",
+			},
+			VATaxRegistration: "DE123456789",
+		},
+		Buyer: Party{
+			Name: "Test Buyer",
+			PostalAddress: &PostalAddress{
+				CountryID:    "FR",
+				PostcodeCode: "75001",
+				City:         "Paris",
+			},
+			VATaxRegistration: "FR987654321",
+		},
+		LineTotal:        decimal.NewFromInt(200),
+		TaxBasisTotal:    decimal.NewFromInt(200),
+		TaxTotal:         decimal.NewFromInt(38),
+		GrandTotal:       decimal.NewFromInt(238),
+		DuePayableAmount: decimal.NewFromInt(238),
+		InvoiceLines: []InvoiceLine{
+			{
+				LineID:                   "1",
+				ItemName:                 "Test Product",
+				BilledQuantity:           decimal.NewFromInt(2),
+				BilledQuantityUnit:       "C62",
+				NetPrice:                 decimal.NewFromInt(100),
+				Total:                    decimal.NewFromInt(200),
+				TaxCategoryCode:          "S",
+				TaxTypeCode:              "VAT",
+				TaxRateApplicablePercent: decimal.NewFromInt(19),
+			},
+			{
+				TaxCategoryCode: "O",
+			},
+		},
+		TradeTaxes: []TradeTax{
+			{
+				CalculatedAmount: decimal.NewFromInt(38),
+				BasisAmount:      decimal.NewFromInt(200),
+				TypeCode:         "VAT",
+				CategoryCode:     "S",
+				Percent:          decimal.NewFromInt(19),
+			},
+		},
+	}
+
+	// Write to buffer
+	var buf bytes.Buffer
+	err := original.Write(&buf)
+	if err != nil {
+		t.Fatalf("Failed to write invoice: %v", err)
+	}
+
+	// Parse back
+	parsed, err := ParseReader(&buf)
+	if err != nil {
+		t.Fatalf("Failed to parse written invoice: %v", err)
+	}
+
+	// Verify key fields
+	if parsed.SchemaType != CII {
+		t.Errorf("Expected SchemaType CII, got %v", parsed.SchemaType)
+	}
+
+	if parsed.InvoiceNumber != original.InvoiceNumber {
+		t.Errorf("InvoiceNumber mismatch: got %s, want %s", parsed.InvoiceNumber, original.InvoiceNumber)
+	}
+
+	if parsed.InvoiceTypeCode != original.InvoiceTypeCode {
+		t.Errorf("InvoiceTypeCode mismatch: got %d, want %d", parsed.InvoiceTypeCode, original.InvoiceTypeCode)
+	}
+
+	if parsed.InvoiceCurrencyCode != original.InvoiceCurrencyCode {
+		t.Errorf("InvoiceCurrencyCode mismatch: got %s, want %s", parsed.InvoiceCurrencyCode, original.InvoiceCurrencyCode)
+	}
+
+	if !parsed.GrandTotal.Equal(original.GrandTotal) {
+		t.Errorf("GrandTotal mismatch: got %s, want %s", parsed.GrandTotal, original.GrandTotal)
+	}
+
+	if len(parsed.InvoiceLines) != len(original.InvoiceLines) {
+		t.Errorf("InvoiceLines count mismatch: got %d, want %d", len(parsed.InvoiceLines), len(original.InvoiceLines))
+	}
+
+	if len(parsed.InvoiceLines) > 0 {
+		if parsed.InvoiceLines[0].ItemName != original.InvoiceLines[0].ItemName {
+			t.Errorf("Line ItemName mismatch: got %s, want %s", parsed.InvoiceLines[0].ItemName, original.InvoiceLines[0].ItemName)
+		}
+		if parsed.InvoiceLines[1].hasTaxRateApplicablePercent {
+			t.Errorf("Line hasTaxRateApplicablePercent is true, should've been false")
+		}
+	}
+}
+
 // TestWrite_MultiCurrencyTaxTotal tests that BT-111 (TaxTotalAmount in accounting currency)
 // is written when TaxCurrencyCode differs from InvoiceCurrencyCode
 func TestWrite_MultiCurrencyTaxTotal(t *testing.T) {

--- a/writer_ubl.go
+++ b/writer_ubl.go
@@ -733,8 +733,10 @@ func writeUBLLineItem(parent *etree.Element, line *InvoiceLine) {
 	// Tax information (before additional properties per UBL ordering)
 	taxCat := item.CreateElement("cac:ClassifiedTaxCategory")
 	taxCat.CreateElement("cbc:ID").SetText(line.TaxCategoryCode)
-	taxCat.CreateElement("cbc:Percent").SetText(formatPercent(line.TaxRateApplicablePercent))
 	taxCat.CreateElement("cac:TaxScheme").CreateElement("cbc:ID").SetText(line.TaxTypeCode)
+	if line.TaxCategoryCode != "O" {
+		taxCat.CreateElement("cbc:Percent").SetText(formatPercent(line.TaxRateApplicablePercent))
+	}
 
 	// BG-32: Item attributes
 	for j := range line.Characteristics {

--- a/writer_ubl.go
+++ b/writer_ubl.go
@@ -733,10 +733,10 @@ func writeUBLLineItem(parent *etree.Element, line *InvoiceLine) {
 	// Tax information (before additional properties per UBL ordering)
 	taxCat := item.CreateElement("cac:ClassifiedTaxCategory")
 	taxCat.CreateElement("cbc:ID").SetText(line.TaxCategoryCode)
-	taxCat.CreateElement("cac:TaxScheme").CreateElement("cbc:ID").SetText(line.TaxTypeCode)
 	if line.TaxCategoryCode != "O" {
 		taxCat.CreateElement("cbc:Percent").SetText(formatPercent(line.TaxRateApplicablePercent))
 	}
+	taxCat.CreateElement("cac:TaxScheme").CreateElement("cbc:ID").SetText(line.TaxTypeCode)
 
 	// BG-32: Item attributes
 	for j := range line.Characteristics {

--- a/writer_ubl_test.go
+++ b/writer_ubl_test.go
@@ -234,6 +234,9 @@ func TestWriteUBL_RoundTrip(t *testing.T) {
 				TaxTypeCode:              "VAT",
 				TaxRateApplicablePercent: decimal.NewFromInt(19),
 			},
+			{
+				TaxCategoryCode: "O",
+			},
 		},
 		TradeTaxes: []TradeTax{
 			{
@@ -287,6 +290,9 @@ func TestWriteUBL_RoundTrip(t *testing.T) {
 	if len(parsed.InvoiceLines) > 0 {
 		if parsed.InvoiceLines[0].ItemName != original.InvoiceLines[0].ItemName {
 			t.Errorf("Line ItemName mismatch: got %s, want %s", parsed.InvoiceLines[0].ItemName, original.InvoiceLines[0].ItemName)
+		}
+		if parsed.InvoiceLines[1].hasTaxRateApplicablePercent {
+			t.Errorf("Line hasTaxRateApplicablePercent is true, should've been false")
 		}
 	}
 }


### PR DESCRIPTION
The FNFE validator enforces the rule BR-O-5, which stipulates :
> An Invoice line (BG-25) where the VAT category code (BT-151) is "Not subject to VAT" shall not contain an Invoiced item VAT rate (BT-152).

We could also remove `RateApplicablePercent` from the document level `ApplicableTradeTax`.
However, the [BR-DE-14](https://github.com/ZUGFeRD/mustangproject/issues/997) says :
> Header vat breakdown (ApplicableTradeTax) must contain RateApplicablePercent (BT-119) even for category O.

So for the best of both world, I only removed `RateApplicablePercent` at the invoice lines level.